### PR TITLE
docs(python): add Raises descriptions for autocomplete #6164

### DIFF
--- a/py/server/deephaven/_gc.py
+++ b/py/server/deephaven/_gc.py
@@ -17,7 +17,7 @@ def garbage_collect() -> None:
     mindful of the overhead that running garbage collection generally incurs.
 
     Raises:
-        DHError
+        DHError: If unable to initiate system-wide garbage collection.
     """
     try:
         gc.collect()

--- a/py/server/deephaven/_table_reader.py
+++ b/py/server/deephaven/_table_reader.py
@@ -78,7 +78,7 @@ def _table_reader_all(
         A Python collection object, usually a dictionary or tuple.
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
     col_defs = _col_defs(table, cols)
 
@@ -124,7 +124,7 @@ def _table_reader_all_dict(
         A dictionary of column names to numpy arrays or Java arrays.
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
 
     def _emitter(col_defs, j_array):
@@ -171,7 +171,7 @@ def _table_reader_chunk(
         A generator that yields the desired Python type of the emitter.
 
     Raises:
-        ValueError
+        ValueError: If chunk_size is negative.
     """
     if chunk_size < 0:
         raise ValueError("chunk_size must not be negative.")
@@ -226,7 +226,7 @@ def _table_reader_chunk_dict(
         A generator that yields a dictionary of column names to numpy arrays or Java arrays.
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
 
     def _emitter(
@@ -271,7 +271,7 @@ def _table_reader_chunk_tuple(
         A generator that yields a named tuple for each row in the table.
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
     named_tuple_class: type[tuple] = namedtuple(  # type: ignore[misc]
         tuple_name, cols or table.column_names, rename=False
@@ -326,7 +326,7 @@ def _table_reader_row_dict(
         A generator that yields a dictionary of column names to values.
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
 
     def _emitter(
@@ -379,7 +379,7 @@ def _table_reader_row_tuple(
         A generator that yields a named tuple for each row in the table
 
     Raises:
-        ValueError
+        ValueError: If a column name is invalid.
     """
     named_tuple_class: type[tuple] = namedtuple(  # type: ignore[misc]
         tuple_name, cols or table.column_names, rename=False

--- a/py/server/deephaven/appmode.py
+++ b/py/server/deephaven/appmode.py
@@ -63,7 +63,7 @@ def get_app_state():
     """Get the current application state object.
 
     Raises:
-         DHError
+         DHError: If unable to get the application state.
     """
     try:
         return ApplicationState(j_app_state=_JApplicationContext.get())

--- a/py/server/deephaven/arrow.py
+++ b/py/server/deephaven/arrow.py
@@ -107,7 +107,7 @@ def to_table(pa_table: pa.Table, cols: Optional[Sequence[str]] = None) -> Table:
         a new table
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if cols:
         pa_table = pa_table.select(cols)
@@ -184,7 +184,7 @@ def read_feather(path: str) -> Table:
          a new table
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     try:
         return Table(j_table=_JArrowWrapperTools.readFeather(path))

--- a/py/server/deephaven/barrage.py
+++ b/py/server/deephaven/barrage.py
@@ -85,7 +85,7 @@ class BarrageSession:
             a Table
 
         Raises:
-            DHError
+            DHError: If unable to subscribe to the remote table with the provided ticket.
         """
         try:
             j_barrage_subscription = self.j_barrage_session.subscribe(
@@ -110,7 +110,7 @@ class BarrageSession:
             a Table
 
         Raises:
-            DHError
+            DHError: If unable to take a snapshot of the remote table with the provided ticket.
         """
         try:
             j_barrage_snapshot = self.j_barrage_session.snapshot(
@@ -157,7 +157,7 @@ def barrage_session(
         a Deephaven Barrage session
 
     Raises:
-        DHError
+        DHError: If unable to get a barrage session to the target remote Deephaven server.
     """
     try:
         if tls_root_certs and not use_tls:

--- a/py/server/deephaven/calendar.py
+++ b/py/server/deephaven/calendar.py
@@ -21,7 +21,7 @@ def remove_calendar(name: str) -> None:
         name (str): the name of the calendar to remove
 
     Raises:
-        DHError
+        DHError: If unable to remove calendar ''.
     """
     try:
         _JCalendars.removeCalendar(name)
@@ -36,7 +36,7 @@ def add_calendar(cal: Union[BusinessCalendar, str]) -> None:
         cal (Union[BusinessCalendar, str]): business calendar or a path to a business calendar file
 
     Raises:
-        DHError
+        DHError: If unable to add calendar from file ''.
     """
 
     if cal is None:
@@ -60,7 +60,7 @@ def set_calendar(name: str) -> None:
         name (str): the name of the calendar
 
     Raises:
-        DHError
+        DHError: If unable to set the default calendar name to ''.
     """
     try:
         _JCalendars.setCalendar(name)
@@ -75,7 +75,7 @@ def calendar_names() -> list[str]:
         a list of all available calendar names
 
     Raises:
-        DHError
+        DHError: If unable to obtain the available calendar names.
     """
     try:
         return list(_JCalendars.calendarNames())
@@ -92,7 +92,7 @@ def calendar_name() -> str:
         the default business calendar name
 
     Raises:
-        DHError
+        DHError: If unable to get the default calendar name.
     """
     try:
         return _JCalendars.calendarName()
@@ -115,7 +115,7 @@ def calendar(name: Optional[str] = None) -> BusinessCalendar:
         the calendar with the given name or the defalt calendar if name is not specified.
 
     Raises:
-        DHError
+        DHError: If unable to get the default calendar.
     """
     try:
         if name is None:

--- a/py/server/deephaven/column.py
+++ b/py/server/deephaven/column.py
@@ -115,7 +115,7 @@ class InputColumn:
             a new InputColumn
 
         Raises:
-            DHError
+            DHError: If unable to create an InputColumn ().
         """
         try:
             self._column_definition = col_def(
@@ -168,7 +168,7 @@ def col_def(
         a new ColumnDefinition
 
     Raises:
-        DHError
+        DHError: If unable to create a ColumnDefinition ().
     """
     try:
         return ColumnDefinition(

--- a/py/server/deephaven/csv.py
+++ b/py/server/deephaven/csv.py
@@ -65,7 +65,7 @@ def read(
         a table
 
     Raises:
-        DHError
+        DHError: If read csv fails.
     """
     try:
         csv_specs_builder = _JCsvTools.builder()
@@ -118,7 +118,7 @@ def write(table: Table, path: str, cols: Sequence[str] = []) -> None:
         cols (Sequence[str]): the names of the columns to be written out
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     try:
         _JCsvTools.writeCsv(table.j_table, False, path, *cols)

--- a/py/server/deephaven/dbc/__init__.py
+++ b/py/server/deephaven/dbc/__init__.py
@@ -25,7 +25,7 @@ def read_sql(
         a new Table
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if isinstance(conn, str):
         if driver == "connectorx":

--- a/py/server/deephaven/dbc/adbc.py
+++ b/py/server/deephaven/dbc/adbc.py
@@ -33,7 +33,8 @@ def read_cursor(cursor: adbc_driver_manager.dbapi.Cursor) -> Table:
         a new Table
 
     Raises:
-        DHError, TypeError
+        DHError: If the operation fails.
+        TypeError: If expect got instead.
     """
 
     if not isinstance(cursor, adbc_driver_manager.dbapi.Cursor):

--- a/py/server/deephaven/dbc/odbc.py
+++ b/py/server/deephaven/dbc/odbc.py
@@ -39,7 +39,8 @@ def read_cursor(cursor: "turbodbc.cursor.Cursor") -> Table:
         a new Table
 
     Raises:
-        DHError, TypeError
+        DHError: If the operation fails.
+        TypeError: If expect got instead.
     """
     if turbodbc is None:
         raise DHError(

--- a/py/server/deephaven/dtypes.py
+++ b/py/server/deephaven/dtypes.py
@@ -260,7 +260,7 @@ def null_remap(dtype: DType) -> Callable[[Any], Any]:
         a Callable
 
     Raises:
-        TypeError
+        TypeError: If null_remap() is not called with a primitive DType.
     """
     null_value = _PRIMITIVE_DTYPE_NULL_MAP.get(dtype)
     if null_value is None:
@@ -332,7 +332,7 @@ def array(
         a Java array
 
     Raises:
-        DHError
+        DHError: If unable to create a Java array.
     """
     if seq is None:
         return None

--- a/py/server/deephaven/execution_context.py
+++ b/py/server/deephaven/execution_context.py
@@ -70,7 +70,7 @@ def make_user_exec_ctx(
         a ExecutionContext
 
     Raises:
-        DHError
+        DHError: If creating the execution context fails.
     """
     freeze_vars = to_sequence(freeze_vars)
 

--- a/py/server/deephaven/experimental/__init__.py
+++ b/py/server/deephaven/experimental/__init__.py
@@ -30,7 +30,7 @@ def time_window(table: Table, ts_col: str, window: int, bool_col: str) -> Table:
         a new Table
 
     Raises:
-        DHError
+        DHError: If unable to create a time window table.
     """
     try:
         with auto_locking_ctx(table):

--- a/py/server/deephaven/experimental/data_index.py
+++ b/py/server/deephaven/experimental/data_index.py
@@ -86,7 +86,7 @@ def data_index(
         a DataIndex or None
 
     Raises:
-        DHError
+        DHError: If unable to create DataIndex.
     """
     try:
         if not create_if_absent:

--- a/py/server/deephaven/experimental/iceberg.py
+++ b/py/server/deephaven/experimental/iceberg.py
@@ -910,7 +910,7 @@ def adapter_s3_rest(
         `IcebergCatalogAdapter`: the catalog adapter for the provided S3 REST catalog.
 
     Raises:
-        DHError: If unable to build the catalog adapter.
+        DHError: If unable to build the catalog adapter..
     """
     if not _JIcebergToolsS3:
         raise DHError(
@@ -952,7 +952,7 @@ def adapter_aws_glue(
         `IcebergCatalogAdapter`: the catalog adapter for the provided AWS Glue catalog.
 
     Raises:
-        DHError: If unable to build the catalog adapter.
+        DHError: If unable to build the catalog adapter..
     """
     if not _JIcebergToolsS3:
         raise DHError(
@@ -1058,7 +1058,7 @@ def adapter(
     `IcebergCatalogAdapter`: the catalog adapter created from the provided properties
 
     Raises:
-        DHError: If unable to build the catalog adapter
+        DHError: If unable to build the catalog adapter.
     """
 
     catalog_options = _build_catalog_options(

--- a/py/server/deephaven/experimental/outer_joins.py
+++ b/py/server/deephaven/experimental/outer_joins.py
@@ -46,7 +46,7 @@ def full_outer_join(
         a new Table
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     try:
         on = ",".join(to_sequence(on))
@@ -90,7 +90,7 @@ def left_outer_join(
         a new Table
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     try:
         on = ",".join(to_sequence(on))

--- a/py/server/deephaven/experimental/sql.py
+++ b/py/server/deephaven/experimental/sql.py
@@ -42,7 +42,7 @@ def evaluate(
         a new Table, or a java TableSpec if dry_run is True
 
     Raises:
-        DHError
+        DHError: If unable to execute SQL.
     """
     try:
         callers_frame_info = inspect.stack()[1]

--- a/py/server/deephaven/experimental/table_data_service.py
+++ b/py/server/deephaven/experimental/table_data_service.py
@@ -313,7 +313,7 @@ class TableDataService(JObjectWrapper):
             Table: a new table
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         j_table_key = _JTableKeyImpl(table_key)
         try:
@@ -335,7 +335,7 @@ class TableDataService(JObjectWrapper):
             PartitionedTable: a new partitioned table
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         j_table_key = _JTableKeyImpl(table_key)
         try:

--- a/py/server/deephaven/filters.py
+++ b/py/server/deephaven/filters.py
@@ -64,7 +64,7 @@ class Filter(ConcurrencyControl["Filter"], JObjectWrapper):
             a new Filter with the given declared barriers
 
         Raises:
-            DHError
+            DHError: If unable to create filter with declared barriers.
         """
         try:
             barriers = to_sequence(barriers)
@@ -84,7 +84,7 @@ class Filter(ConcurrencyControl["Filter"], JObjectWrapper):
             a new Filter with the given respected barriers
 
         Raises:
-            DHError
+            DHError: If unable to create filter with respected barriers.
         """
         try:
             barriers = to_sequence(barriers)
@@ -99,7 +99,7 @@ class Filter(ConcurrencyControl["Filter"], JObjectWrapper):
             a new Filter with serial evaluation enforced
 
         Raises:
-            DHError
+            DHError: If unable to create filter with serial evaluation.
         """
         try:
             return Filter(j_filter=self.j_filter.withSerial())
@@ -127,7 +127,7 @@ class Filter(ConcurrencyControl["Filter"], JObjectWrapper):
             filter(s)
 
         Raises:
-            DHError
+            DHError: If unable to create filters.
         """
         conditions = to_sequence(conditions)
         try:
@@ -238,7 +238,7 @@ def pattern(
         a new pattern filter
 
     Raises:
-        DHError
+        DHError: If unable to create a pattern filter.
     """
     try:
         return Filter(
@@ -267,7 +267,7 @@ def incremental_release(initial_rows: int, increment: int) -> Filter:
         a new incremental release filter
 
     Raises:
-        DHError
+        DHError: If unable to create incremental release filter.
     """
     try:
         return Filter(j_filter=_JIncrementalReleaseFilter(initial_rows, increment))
@@ -286,7 +286,7 @@ def in_(col: str, values: Sequence[Union[bool, int, float, str]]) -> Filter:
         a new in Filter
 
     Raises:
-        DHError
+        DHError: If unable to create an in filter.
     """
     try:
         j_literals = [_JLiteral.of(v) for v in values]

--- a/py/server/deephaven/html.py
+++ b/py/server/deephaven/html.py
@@ -19,7 +19,7 @@ def to_html(table: Table) -> str:
         a HTML string
 
     Raises:
-        DHError
+        DHError: If table to_html fails.
     """
     try:
         return _JTableTools.html(table.j_table)

--- a/py/server/deephaven/jcompat.py
+++ b/py/server/deephaven/jcompat.py
@@ -308,7 +308,7 @@ def _j_array_to_sequence(j_array: jpy.JType) -> Sequence[Any]:
         Sequence[Any]: a sequence of wrapped objects or an empty tuple if the input is None
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if j_array is None:
         return ()
@@ -332,7 +332,7 @@ def _j_array_to_numpy_array(
         np.ndarray: The numpy array or None if the Java array is None
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
 
     if dtype.is_primitive:
@@ -379,7 +379,7 @@ def dh_null_to_nan(np_array: np.ndarray, type_promotion: bool = False) -> np.nda
         np.ndarray: The numpy array with Deephaven nulls converted to np.nan.
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if not isinstance(np_array, np.ndarray):
         raise DHError(message="The given np_array argument is not a numpy array.")
@@ -419,7 +419,7 @@ def _j_array_to_series(dtype: DType, j_array: jpy.JType, conv_null: bool) -> pd.
         a pandas Series
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if conv_null and dtype == dtypes.bool_:
         j_array = _JPrimitiveArrayConversionUtility.translateArrayBooleanToByte(j_array)
@@ -462,7 +462,7 @@ def j_table_definition(
         a Deephaven TableDefinition object or None if the input is None
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     warn(
         "j_table_definition is deprecated for removal next release, prefer TableDefinition",

--- a/py/server/deephaven/learn/__init__.py
+++ b/py/server/deephaven/learn/__init__.py
@@ -142,7 +142,7 @@ def learn(
         a Table with added columns containing the results of evaluating model_func.
 
     Raises:
-        DHError
+        DHError: If unable to complete the learn function.
     """
 
     try:

--- a/py/server/deephaven/learn/gather.py
+++ b/py/server/deephaven/learn/gather.py
@@ -65,7 +65,7 @@ def table_to_numpy_2d(
         a np.ndarray
 
     Raises:
-        DHError
+        DHError: If unable to convert rows: and cols: to a 2D NumPy array.
     """
 
     try:

--- a/py/server/deephaven/liveness_scope.py
+++ b/py/server/deephaven/liveness_scope.py
@@ -108,7 +108,7 @@ class _BaseLivenessScope(JObjectWrapper):
         """Closes the LivenessScope and releases all the query graph resources.
 
         Raises:
-            DHError if this instance has been released too many times
+            DHError: If this instance has been released too many times.
         """
         try:
             self.j_scope.release()
@@ -123,7 +123,7 @@ class _BaseLivenessScope(JObjectWrapper):
             referent (Union[JObjectWrapper, jpy.JType]): an object to preserve in the next outer liveness scope
 
         Raises:
-            DHError if the object isn't a liveness node, or this instance isn't currently at the stop of the stack
+            DHError: If the object is not a liveness node, or this instance is not currently at the top of the stack.
         """
         referent = _unwrap_to_liveness_referent(referent)
         try:
@@ -157,7 +157,7 @@ class _BaseLivenessScope(JObjectWrapper):
         Returns: None
 
         Raises:
-            DHError if the referent isn't a LivenessReferent, or if it is no longer live
+            DHError: If the referent is not a LivenessReferent, or if it is no longer live.
 
         """
         referent = _unwrap_to_liveness_referent(referent)
@@ -177,7 +177,7 @@ class _BaseLivenessScope(JObjectWrapper):
         Returns: None
 
         Raises:
-            DHError if the referent isn't a LivenessReferent, or if it is no longer live
+            DHError: If the referent is not a LivenessReferent, or if it is no longer live.
 
         """
         referent = _unwrap_to_liveness_referent(referent)
@@ -212,7 +212,7 @@ class LivenessScope(_BaseLivenessScope):
         """Closes the LivenessScope and releases all the managed resources.
 
         Raises:
-            DHError if this instance has been released too many times
+            DHError: If this instance has been released too many times.
         """
         self._release()
 

--- a/py/server/deephaven/numpy.py
+++ b/py/server/deephaven/numpy.py
@@ -39,7 +39,7 @@ def _column_to_numpy_array(col_def: ColumnDefinition, j_array: jpy.JType) -> np.
         np.ndarray
 
     Raises:
-        DHError
+        DHError: If unable to create a numpy array for the column.
     """
     try:
         return _j_array_to_numpy_array(

--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -50,7 +50,7 @@ def _column_to_series(
         a pandas Series
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     try:
         j_array = _JColumnVectors.of(table.j_table, col_def.name).copyToArray()

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -308,7 +308,7 @@ def read(
         a table
 
     Raises:
-        DHError
+        DHError: If unable to read parquet data.
     """
 
     try:
@@ -342,7 +342,7 @@ def delete(path: str) -> None:
         path (str): path to delete
 
     Raises:
-        DHError
+        DHError: If unable to delete a parquet table: on disk.
     """
     try:
         _JParquetTools.deleteTable(path)
@@ -399,7 +399,7 @@ def write(
         special_instructions (Optional[s3.S3Instructions]): Special instructions for writing parquet files, useful when
             writing files to a non-local file system, like S3. By default, None.
     Raises:
-        DHError
+        DHError: If unable to write to parquet data.
     """
     try:
         write_instructions = _build_parquet_instructions(
@@ -487,7 +487,7 @@ def write_partitioned(
             writing files to a non-local file system, like S3. By default, None.
 
     Raises:
-        DHError
+        DHError: If unable to write to parquet data.
     """
     try:
         write_instructions = _build_parquet_instructions(
@@ -562,7 +562,7 @@ def batch_write(
             writing files to a non-local file system, like S3. By default, None.
 
     Raises:
-        DHError
+        DHError: If write multiple tables to parquet data fails.
     """
     try:
         write_instructions = _build_parquet_instructions(

--- a/py/server/deephaven/perfmon.py
+++ b/py/server/deephaven/perfmon.py
@@ -43,7 +43,7 @@ def process_info_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the process info log table.
     """
     try:
         return Table(j_table=_JTableLoggers.processInfoLog())
@@ -59,7 +59,7 @@ def server_state_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the server state log table.
     """
     try:
         return Table(j_table=_JTableLoggers.serverStateLog())
@@ -74,7 +74,7 @@ def process_metrics_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the process metrics log table.
     """
     try:
         return Table(j_table=_JTableLoggers.processMetricsLog())
@@ -90,7 +90,7 @@ def query_operation_performance_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query operation performance log table.
     """
     try:
         return Table(j_table=_JTableLoggers.queryOperationPerformanceLog())
@@ -108,7 +108,7 @@ def query_performance_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query performance log table.
     """
     try:
         return Table(j_table=_JTableLoggers.queryPerformanceLog())
@@ -123,7 +123,7 @@ def query_operation_performance_tree_table() -> TreeTable:
         a TreeTable
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query operation performance log as tree table.
     """
     try:
         with auto_locking_ctx(query_performance_log()):
@@ -146,7 +146,7 @@ def query_performance_tree_table() -> TreeTable:
         a TreeTable
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query performance log as tree table.
     """
     try:
         with auto_locking_ctx(query_performance_log()):
@@ -168,7 +168,7 @@ def update_performance_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the update performance log table.
     """
     try:
         return Table(j_table=_JTableLoggers.updatePerformanceLog())
@@ -183,7 +183,7 @@ def update_performance_ancestors_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the update performance log table.
     """
     try:
         return Table(j_table=_JTableLoggers.updatePerformanceAncestorsLog())
@@ -199,7 +199,7 @@ def barrage_subscription_performance_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the barrage subscription performance log table.
     """
     try:
         return Table(
@@ -219,7 +219,7 @@ def barrage_snapshot_performance_log() -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to obtain the barrage snapshot performance log table.
     """
     try:
         return Table(j_table=_JBarragePerformanceLog.getInstance().getSnapshotTable())
@@ -255,7 +255,7 @@ def process_info(proc_id: str, proc_type: str, key: str) -> str:
         a string of process information
 
     Raises:
-        DHError
+        DHError: If unable to obtain the process info.
     """
     try:
         return _JPerformanceQueries.processInfo(proc_id, proc_type, key)
@@ -293,7 +293,7 @@ def query_operation_performance(eval_number: int) -> Table:
         a table of query operation performance data
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query operation performance data.
     """
     try:
         return Table(
@@ -325,7 +325,7 @@ def query_performance(eval_number: int) -> Table:
         a Table of query performance data
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query performance data.
     """
     try:
         return Table(j_table=_JPerformanceQueries.queryPerformance(eval_number))
@@ -346,7 +346,7 @@ def query_update_performance(eval_number: int) -> Table:
         a Table of query update performance data
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query update performance data.
     """
     try:
         return Table(j_table=_JPerformanceQueries.queryUpdatePerformance(eval_number))
@@ -366,7 +366,7 @@ def query_update_performance_map(eval_number: int) -> dict[str, Table]:
         a dict
 
     Raises:
-        DHError
+        DHError: If unable to obtain the query update perf map.
     """
 
     try:
@@ -397,7 +397,7 @@ def ancestor_svg(
         the contents of an SVG image
 
     Raises:
-        DHError
+        DHError: If unable to produce ancestor SVG.
     """
     try:
         if isinstance(ids, int):
@@ -429,7 +429,7 @@ def ancestor_image(
         a UI component with an embedded graph of ancestors
 
     Raises:
-        DHError
+        DHError: If unable to produce ancestor image.
     """
 
     try:
@@ -463,7 +463,7 @@ def ancestor_dot(
         a string of graphviz DOT format data
 
     Raises:
-        DHError
+        DHError: If unable to produce ancestor DOT file.
     """
     try:
         if isinstance(ids, int):

--- a/py/server/deephaven/plot/axistransform.py
+++ b/py/server/deephaven/plot/axistransform.py
@@ -42,7 +42,7 @@ def axis_transform(name: str) -> AxisTransform:
         a AxisTransform
 
     Raises:
-        DHError
+        DHError: If unable to retrieve the named AxisTransform.
     """
     try:
         return AxisTransform(j_axis_transform=_JPlottingConvenience.axisTransform(name))

--- a/py/server/deephaven/plot/color.py
+++ b/py/server/deephaven/plot/color.py
@@ -44,7 +44,7 @@ class Color(JObjectWrapper):
              a Color
 
         Raises:
-            DHError
+            DHError: If unable to get a color by its name.
         """
         try:
             return Color(j_color=_JColor.color(name))
@@ -66,7 +66,7 @@ class Color(JObjectWrapper):
             a Color
 
         Raises:
-            DHError
+            DHError: If unable to create a color from rgb values.
         """
         try:
             return Color(j_color=_JColor.colorRGB(r, g, b, alpha))
@@ -88,7 +88,7 @@ class Color(JObjectWrapper):
             a color
 
         Raises:
-            DHError
+            DHError: If unable to create a color from rgb values.
         """
         try:
             return Color(j_color=_JColor.colorRGB(r, g, b, alpha))
@@ -111,7 +111,7 @@ class Color(JObjectWrapper):
             a Color
 
         Raises:
-            DHError
+            DHError: If unable to create a color from hue, saturation, lightness values.
         """
         try:
             return Color(j_color=_JColor.colorHSL(h, s, l, alpha))

--- a/py/server/deephaven/plot/figure.py
+++ b/py/server/deephaven/plot/figure.py
@@ -37,7 +37,7 @@ def _assert_type(name: str, obj: Any, types: List) -> None:
         types (List): acceptable types for the object
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
 
     types_no_subscript = tuple(set(t.__origin__ if isinstance(t, _GenericAlias) else t for t in types))
@@ -65,7 +65,7 @@ def _convert_j(name: str, obj: Any, types: List) -> Any:
         types (List): acceptable types for the object
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
 
     if obj is None:
@@ -142,7 +142,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -226,7 +226,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -401,7 +401,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -533,7 +533,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -597,7 +597,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -690,7 +690,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -755,7 +755,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -809,7 +809,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -865,7 +865,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -943,7 +943,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -982,7 +982,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -1030,7 +1030,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1090,7 +1090,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1140,7 +1140,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1199,7 +1199,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1252,7 +1252,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1329,7 +1329,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1426,7 +1426,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: series_name.
         """
         if not series_name:
             raise DHError("required parameter is not set: series_name")
@@ -1493,7 +1493,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -1758,7 +1758,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If required parameter is not set: path.
         """
         if not path:
             raise DHError("required parameter is not set: path")
@@ -1824,7 +1824,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -1978,7 +1978,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2008,7 +2008,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2076,7 +2076,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2120,7 +2120,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2179,7 +2179,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2337,7 +2337,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2405,7 +2405,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2447,7 +2447,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2499,7 +2499,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2657,7 +2657,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2725,7 +2725,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 
@@ -2767,7 +2767,7 @@ class Figure(JObjectWrapper):
             a new Figure
 
         Raises:
-            DHError
+            DHError: If unsupported parameter combination.
         """
         non_null_args = set()
 

--- a/py/server/deephaven/plot/linestyle.py
+++ b/py/server/deephaven/plot/linestyle.py
@@ -77,7 +77,7 @@ class LineStyle(JObjectWrapper):
             dash_pattern (Optional[list[Number]] ): a list of number specifying the dash pattern of the line
 
         Raises:
-            DHError
+            DHError: If unable to create a LineStyle.
         """
         try:
             if dash_pattern:

--- a/py/server/deephaven/plot/selectable_dataset.py
+++ b/py/server/deephaven/plot/selectable_dataset.py
@@ -46,7 +46,7 @@ def one_click(
         a SelectableDataSet
 
     Raises:
-        DHError
+        DHError: If creating the SelectableDataSet fails.
     """
     if not by:
         by = []
@@ -72,7 +72,7 @@ def one_click_partitioned_table(
         a SelectableDataSet
 
     Raises:
-        DHError
+        DHError: If creating the SelectableDataSet fails.
     """
     try:
         return SelectableDataSet(

--- a/py/server/deephaven/query_library.py
+++ b/py/server/deephaven/query_library.py
@@ -22,7 +22,7 @@ def import_class(name: str) -> None:
         name (str): the fully qualified name of the Java class
 
     Raises:
-        DHError
+        DHError: If unable to add the Java class to the Query Library.
     """
     try:
         j_class = _JClass.forName(name)
@@ -40,7 +40,7 @@ def import_static(name: str) -> None:
         name (str): the fully qualified name of the Java class
 
     Raises:
-        DHError
+        DHError: If unable to add the static members of the Java class to the Query Library.
     """
     try:
         j_class = _JClass.forName(name)
@@ -61,7 +61,7 @@ def import_package(name: str) -> None:
         name (str): the fully qualified name of the Java package
 
     Raises:
-        DHError
+        DHError: If unable to add the Java package into to the Query Library.
     """
     try:
         j_package = _JPackage.getPackage(name)

--- a/py/server/deephaven/replay.py
+++ b/py/server/deephaven/replay.py
@@ -33,7 +33,7 @@ class TableReplayer(JObjectWrapper):
                 replay end time.  Integer values are nanoseconds since the Epoch.
 
         Raises:
-            DHError
+            DHError: If unable to create a replayer.
         """
         start_time = time.to_j_instant(start_time)
         end_time = time.to_j_instant(end_time)
@@ -59,7 +59,7 @@ class TableReplayer(JObjectWrapper):
             a replay Table
 
         Raises:
-            DHError
+            DHError: If unable to add a historical table.
         """
         try:
             replay_table = Table(j_table=self._j_replayer.replay(table.j_table, col))
@@ -71,7 +71,7 @@ class TableReplayer(JObjectWrapper):
         """Starts replaying.
 
         Raises:
-             DHError
+             DHError: If unable to start the replayer.
         """
         try:
             self._j_replayer.start()

--- a/py/server/deephaven/server/executors.py
+++ b/py/server/deephaven/server/executors.py
@@ -45,7 +45,7 @@ def submit_task(executor_name: str, task: Callable[[], None]) -> None:
         task (Callable[[], None]): the function to run on the named executor
 
     Raises:
-         KeyError if the executor name
+         KeyError: If no executor exists with that name.
     """
     _executors[executor_name](task)
 
@@ -59,7 +59,7 @@ def _register_named_java_executor(executor_name: str, java_executor: jpy.JType) 
         java_executor (jpy.JType): a Java Consumer<Runnable> instance
 
     Raises:
-        DHError
+        DHError: If an executor with that name is already registered.
     """
     if executor_name in executor_names():
         raise DHError(f"Executor with name {executor_name} already registered")

--- a/py/server/deephaven/stream/__init__.py
+++ b/py/server/deephaven/stream/__init__.py
@@ -33,7 +33,7 @@ def add_only_to_blink(table: Table) -> Table:
         a blink table
 
     Raises:
-        DHError
+        DHError: If unable to create a blink table.
     """
     try:
         return Table(j_table=_JAddOnlyToBlinkTableAdapter.toBlink(table.j_table))
@@ -51,7 +51,7 @@ def blink_to_append_only(table: Table) -> Table:
         an append-only table
 
     Raises:
-        DHError
+        DHError: If unable to create an append-only table.
     """
     try:
         return Table(j_table=_JBlinkTableTools.blinkToAppendOnly(table.j_table))

--- a/py/server/deephaven/stream/kafka/__init__.py
+++ b/py/server/deephaven/stream/kafka/__init__.py
@@ -24,7 +24,7 @@ def topics(kafka_config: dict) -> list[str]:
         a list of topic names
 
     Raises:
-        DHError
+        DHError: If unable to list Kafka topics.
     """
     try:
         j_kafka_config = j_properties(kafka_config)

--- a/py/server/deephaven/stream/kafka/cdc.py
+++ b/py/server/deephaven/stream/kafka/cdc.py
@@ -60,7 +60,7 @@ def consume(
         a Deephaven live table that will update based on the CDC messages consumed for the given topic
 
     Raises:
-        DHError
+        DHError: If unable to consume a CDC stream.
     """
     try:
         partitions = _j_partitions(partitions)
@@ -99,7 +99,7 @@ def consume_raw(
         a Deephaven live table for the raw CDC events
 
     Raises:
-        DHError
+        DHError: If unable to consume a raw CDC stream.
     """
     try:
         partitions = _j_partitions(partitions)
@@ -139,7 +139,7 @@ def cdc_long_spec(
         a CDCSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a CDC spec in cdc_long_spec.
     """
     try:
         return CDCSpec(
@@ -172,7 +172,7 @@ def cdc_short_spec(server_name: str, db_name: str, table_name: str):
         a CDCSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a CDC spec in cdc_short_spec.
     """
     try:
         return CDCSpec(j_spec=_JCdcTools.cdcShortSpec(server_name, db_name, table_name))

--- a/py/server/deephaven/stream/kafka/consumer.py
+++ b/py/server/deephaven/stream/kafka/consumer.py
@@ -202,7 +202,7 @@ def consume(
         a Deephaven live table that will update based on Kafka messages consumed for the given topic
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if table_type is None:
         table_type = TableType.blink()
@@ -264,7 +264,7 @@ def consume_to_partitioned_table(
         topic partition.
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     if table_type is None:
         table_type = TableType.blink()
@@ -467,7 +467,7 @@ def avro_spec(
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         mapping_func: Optional[Callable[[str], str]] = (
@@ -519,7 +519,7 @@ def json_spec(
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         try:
@@ -558,7 +558,7 @@ def simple_spec(col_name: str, data_type: Optional[DType] = None) -> KeyValueSpe
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         if data_type is None:
@@ -581,6 +581,6 @@ def object_processor_spec(provider: jpy.JType) -> KeyValueSpec:
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     return KeyValueSpec(j_spec=_JKafkaTools_Consume.objectProcessorSpec(provider))

--- a/py/server/deephaven/stream/kafka/producer.py
+++ b/py/server/deephaven/stream/kafka/producer.py
@@ -94,7 +94,7 @@ def produce(
         publishing is desired, and once not desired anymore they should invoke it
 
     Raises:
-        DHError
+        DHError: If unable to start producing Kafka messages.
     """
     try:
         if key_spec is KeyValueSpec.IGNORE and value_spec is KeyValueSpec.IGNORE:
@@ -182,7 +182,7 @@ def avro_spec(
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         field_to_col_mapping = j_hashmap(field_to_col_mapping)
@@ -244,7 +244,7 @@ def json_spec(
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         if include_columns is not None and exclude_columns is not None:
@@ -276,7 +276,7 @@ def simple_spec(col_name: str) -> KeyValueSpec:
         a KeyValueSpec
 
     Raises:
-        DHError
+        DHError: If unable to create a Kafka key/value spec.
     """
     try:
         return KeyValueSpec(_JKafkaTools_Produce.simpleSpec(col_name))

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -164,7 +164,7 @@ class Selectable(ConcurrencyControl["Selectable"], JObjectWrapper):
             Selectable
 
         Raises:
-            DHError
+            DHError: If unable to create a Selectable.
         """
         try:
             return Selectable(j_selectable=_JSelectable.parse(formula))
@@ -183,7 +183,7 @@ class Selectable(ConcurrencyControl["Selectable"], JObjectWrapper):
             Selectable
 
         Raises:
-            DHError
+            DHError: If unable to create selectable with declared barriers.
         """
         try:
             barriers = to_sequence(barriers)
@@ -207,7 +207,7 @@ class Selectable(ConcurrencyControl["Selectable"], JObjectWrapper):
             Selectable
 
         Raises:
-            DHError
+            DHError: If unable to create selectable with respected barriers.
         """
         try:
             barriers = to_sequence(barriers)
@@ -226,7 +226,7 @@ class Selectable(ConcurrencyControl["Selectable"], JObjectWrapper):
             Selectable
 
         Raises:
-            DHError
+            DHError: If unable to create selectable with serial evaluation.
         """
         try:
             return Selectable(j_selectable=self.j_selectable.withSerial())
@@ -444,7 +444,7 @@ class RollupTable(JObjectWrapper):
             a RollupNodeOperationsRecorder
 
         Raises:
-            DHError
+            DHError: If unable to create a RollupNodeOperationsRecorder.
         """
         try:
             return RollupNodeOperationsRecorder(
@@ -470,7 +470,7 @@ class RollupTable(JObjectWrapper):
             a new RollupTable
 
         Raises:
-            DHError
+            DHError: If with_node_operations on RollupTable fails.
         """
         try:
             return RollupTable(
@@ -497,7 +497,7 @@ class RollupTable(JObjectWrapper):
             a new RollupTable
 
         Raises:
-            DHError
+            DHError: If with_filters operation on RollupTable fails.
         """
         try:
             return RollupTable(
@@ -519,7 +519,7 @@ class RollupTable(JObjectWrapper):
             a new RollupTable
 
         Raises:
-            DHError
+            DHError: If with_update_view operation on RollupTable fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -602,7 +602,7 @@ class TreeTable(JObjectWrapper):
             a new TreeTable
 
         Raises:
-            DHError
+            DHError: If with_node_operations on TreeTable fails.
         """
 
         try:
@@ -629,7 +629,7 @@ class TreeTable(JObjectWrapper):
             a new TreeTable
 
         Raises:
-            DHError
+            DHError: If with_filters operation on TreeTable fails.
         """
 
         try:
@@ -751,7 +751,7 @@ class TableDefinition(JObjectWrapper, Mapping):
             A new TableDefinition
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         self.j_table_definition = TableDefinition._to_j_table_definition(
             table_definition
@@ -926,7 +926,7 @@ class Table(JObjectWrapper):
             A generator that yields a dictionary of column names to scalar values.
 
         Raises:
-            ValueError
+            ValueError: If the argument value is invalid.
         """
         from deephaven._table_reader import (
             _table_reader_row_dict,
@@ -966,7 +966,7 @@ class Table(JObjectWrapper):
             A generator that yields a named tuple for each row in the table
 
         Raises:
-            ValueError
+            ValueError: If the argument value is invalid.
         """
         from deephaven._table_reader import (
             _table_reader_row_tuple,
@@ -1043,7 +1043,7 @@ class Table(JObjectWrapper):
             A generator that yields a named tuple for each row in the table.
 
         Raises:
-            ValueError
+            ValueError: If the argument value is invalid.
         """
         from deephaven._table_reader import (
             _table_reader_chunk_tuple,
@@ -1086,7 +1086,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to create a table with attributes.
         """
         try:
             j_map = j_hashmap(attrs)
@@ -1107,7 +1107,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to create a table without attributes.
         """
         try:
             j_attrs = j_array_list(to_sequence(attrs))
@@ -1130,7 +1130,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to create a table with key columns.
         """
         try:
             cols = to_sequence(cols)
@@ -1149,7 +1149,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to create a table with unique key columns.
         """
         try:
             cols = to_sequence(cols)
@@ -1170,7 +1170,7 @@ class Table(JObjectWrapper):
             string
 
         Raises:
-            DHError
+            DHError: If table to_string fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1197,7 +1197,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         try:
             with auto_locking_ctx(self):
@@ -1241,7 +1241,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         try:
             options = _JSnapshotWhenOptions.of(
@@ -1269,7 +1269,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table drop_columns operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1290,7 +1290,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table move_columns operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1311,7 +1311,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table move_columns_down operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1332,7 +1332,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table move_columns_up operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1353,7 +1353,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table rename_columns operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1374,7 +1374,7 @@ class Table(JObjectWrapper):
             A new table
 
         Raises:
-            DHError
+            DHError: If table update operation fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -1396,7 +1396,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table lazy_update operation fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -1415,7 +1415,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table view operation fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -1434,7 +1434,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table update_view operation fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -1460,7 +1460,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table select operation fails.
         """
         try:
             with query_scope_ctx(), auto_locking_ctx(self):
@@ -1489,7 +1489,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table select_distinct operation fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -1520,7 +1520,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table where operation fails.
         """
         try:
             filters = to_sequence(filters)
@@ -1541,7 +1541,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table where_in operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1564,7 +1564,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table where_not_in operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1590,7 +1590,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table where_one_of operation fails.
         """
         try:
             filters = to_sequence(filters)
@@ -1609,7 +1609,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table head operation fails.
         """
         try:
             return Table(j_table=self.j_table.head(num_rows))
@@ -1626,7 +1626,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table head_pct operation fails.
         """
         try:
             return Table(j_table=self.j_table.headPct(pct))
@@ -1643,7 +1643,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table tail operation fails.
         """
         try:
             return Table(j_table=self.j_table.tail(num_rows))
@@ -1660,7 +1660,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table tail_pct operation fails.
         """
         try:
             return Table(j_table=self.j_table.tailPct(pct))
@@ -1685,7 +1685,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table restrict_sort_to operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -1704,7 +1704,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table sort_descending operation fails.
         """
         try:
             order_by = to_sequence(order_by)
@@ -1719,7 +1719,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table reverse operation fails.
         """
         try:
             return Table(j_table=self.j_table.reverse())
@@ -1742,7 +1742,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table sort operation fails.
         """
 
         try:
@@ -1799,7 +1799,7 @@ class Table(JObjectWrapper):
             a new Table with the sorted-column attribute set.
 
         Raises:
-            DHError
+            DHError: If table with_order_for_column operation fails.
         """
         try:
             return Table(
@@ -1831,7 +1831,7 @@ class Table(JObjectWrapper):
             a new Table with the sorted-column assertion applied.
 
         Raises:
-            DHError
+            DHError: If table assert_sorted operation fails.
         """
         try:
             return Table(
@@ -1874,7 +1874,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table natural_join operation fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -1910,7 +1910,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table exact_join operation fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -1951,7 +1951,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table join operation fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -1996,7 +1996,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table as-of join operation fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -2032,7 +2032,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table reverse-as-of join operation fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -2143,7 +2143,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If the operation fails.
         """
         try:
             on = to_sequence(on)
@@ -2176,7 +2176,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table head_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2198,7 +2198,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table tail_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2218,7 +2218,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table group-by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2241,7 +2241,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table ungroup operation fails.
         """
         try:
             cols = to_sequence(cols)
@@ -2263,7 +2263,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table first_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2284,7 +2284,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table last_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2305,7 +2305,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table sum_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2326,7 +2326,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table asb_sum_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2350,7 +2350,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table weighted_sum_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2371,7 +2371,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table avg_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2395,7 +2395,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table avg_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2420,7 +2420,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table std_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2444,7 +2444,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table var_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2465,7 +2465,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table median_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2486,7 +2486,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table min_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2507,7 +2507,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table max_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2531,7 +2531,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table count_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2571,7 +2571,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table agg_by operation fails.
         """
         try:
             aggs = to_sequence(aggs)
@@ -2632,7 +2632,7 @@ class Table(JObjectWrapper):
             a PartitionedTable
 
         Raises:
-            DHError
+            DHError: If table partitioned_agg_by operation fails.
         """
         try:
             aggs = to_sequence(aggs)
@@ -2667,7 +2667,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table agg_all_by operation fails.
         """
         try:
             by = to_sequence(by)
@@ -2690,7 +2690,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If unable to color format columns.
         """
         try:
             formulas = to_sequence(formulas)
@@ -2712,7 +2712,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If unable to color format column conditionally.
         """
         try:
             with query_scope_ctx():
@@ -2732,7 +2732,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If unable to color format rows conditionally.
         """
         try:
             with query_scope_ctx():
@@ -2774,7 +2774,7 @@ class Table(JObjectWrapper):
             a new table with the layout hints set
 
         Raises:
-            DHError
+            DHError: If unable to create layout hints.
         """
         try:
             _j_layout_hint_builder = _JLayoutHintBuilder.get()
@@ -2825,7 +2825,7 @@ class Table(JObjectWrapper):
             A PartitionedTable containing a sub-table for each group
 
         Raises:
-            DHError
+            DHError: If unable to create a partitioned table.
         """
         try:
             if not isinstance(drop_keys, bool):
@@ -2856,7 +2856,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If table update-by operation fails.
         """
         try:
             ops = to_sequence(ops)
@@ -2891,7 +2891,7 @@ class Table(JObjectWrapper):
             a new Table
 
         Raises:
-            DHError
+            DHError: If table slice operation fails.
 
         Examples:
             >>> table.slice(0, 5)    # first 5 rows
@@ -2924,7 +2924,7 @@ class Table(JObjectWrapper):
             a new table
 
         Raises:
-            DHError
+            DHError: If table slice_pct operation fails.
         """
         try:
             return Table(j_table=self.j_table.slicePct(start_pct, end_pct))
@@ -2955,7 +2955,7 @@ class Table(JObjectWrapper):
             a new RollupTable
 
         Raises:
-            DHError
+            DHError: If table rollup operation fails.
         """
         try:
             aggs = to_sequence(aggs)
@@ -3009,7 +3009,7 @@ class Table(JObjectWrapper):
             a new TreeTable organized according to the parent-child relationships expressed by id_col and parent_col
 
         Raises:
-            DHError
+            DHError: If table tree operation fails.
         """
         try:
             if promote_orphans:
@@ -3038,7 +3038,7 @@ class Table(JObjectWrapper):
             True when the table is updated or False when the timeout has been reached.
 
         Raises:
-            DHError
+            DHError: If await_update was interrupted.
         """
         if not self.is_refreshing:
             raise DHError(
@@ -3177,7 +3177,7 @@ class PartitionedTable(JObjectWrapper):
             a PartitionedTable
 
         Raises:
-            DHError
+            DHError: If unable to create a PartitionedTable from constituent tables.
         """
         try:
             if not constituent_table_columns:
@@ -3278,7 +3278,7 @@ class PartitionedTable(JObjectWrapper):
             a Table
 
         Raises:
-            DHError
+            DHError: If unable to merge all the constituent tables.
         """
         try:
             with auto_locking_ctx(self):
@@ -3300,7 +3300,7 @@ class PartitionedTable(JObjectWrapper):
              a PartitionedTable
 
         Raises:
-            DHError
+            DHError: If unable to apply filters to the partitioned table.
         """
         filters = to_sequence(filters)
         if isinstance(filters[0], str):
@@ -3332,7 +3332,7 @@ class PartitionedTable(JObjectWrapper):
             a new PartitionedTable
 
         Raises:
-            DHError
+            DHError: If unable to sort the partitioned table.
         """
 
         try:
@@ -3366,7 +3366,7 @@ class PartitionedTable(JObjectWrapper):
             a Table or None
 
         Raises:
-            DHError
+            DHError: If unable to get constituent table.
         """
         try:
             key_values = to_sequence(key_values)
@@ -3403,7 +3403,7 @@ class PartitionedTable(JObjectWrapper):
             a PartitionedTable
 
         Raises:
-            DHError
+            DHError: If unable to transform the PartitionedTable.
         """
         try:
             j_operator = j_unary_operator(
@@ -3456,7 +3456,7 @@ class PartitionedTable(JObjectWrapper):
             a PartitionedTable
 
         Raises:
-            DHError
+            DHError: If unable to transform the PartitionedTable with another PartitionedTable.
         """
         try:
             j_operator = j_binary_operator(
@@ -3558,7 +3558,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If head operation on the PartitionedTableProxy fails.
         """
         try:
             with auto_locking_ctx(self):
@@ -3580,7 +3580,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If tail operation on the PartitionedTableProxy fails.
         """
         try:
             with auto_locking_ctx(self):
@@ -3599,7 +3599,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If reverse operation on the PartitionedTableProxy fails.
         """
         try:
             with auto_locking_ctx(self):
@@ -3618,7 +3618,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If snapshot operation on the PartitionedTableProxy fails.
         """
         try:
             with auto_locking_ctx(self):
@@ -3661,7 +3661,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If snapshot_when operation on the PartitionedTableProxy fails.
         """
         try:
             options = _JSnapshotWhenOptions.of(
@@ -3696,7 +3696,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If sort operation on the PartitionedTableProxy fails.
         """
         try:
             if not order:
@@ -3742,7 +3742,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If sort_descending operation on the PartitionedTableProxy fails.
         """
         try:
             order_by = to_sequence(order_by)
@@ -3771,7 +3771,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If where operation on the PartitionedTableProxy fails.
         """
         try:
             filters = to_sequence(filters)
@@ -3799,7 +3799,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If where_in operation on the PartitionedTableProxy fails.
         """
         try:
             cols = to_sequence(cols)
@@ -3827,7 +3827,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If where_not_in operation on the PartitionedTableProxy fails.
         """
         try:
             cols = to_sequence(cols)
@@ -3852,7 +3852,7 @@ class PartitionedTableProxy(JObjectWrapper):
             A new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If view operation on the PartitionedTableProxy fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -3875,7 +3875,7 @@ class PartitionedTableProxy(JObjectWrapper):
             A new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If update_view operation on the PartitionedTableProxy fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -3903,7 +3903,7 @@ class PartitionedTableProxy(JObjectWrapper):
             A new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If update operation on the PartitionedTableProxy fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -3939,7 +3939,7 @@ class PartitionedTableProxy(JObjectWrapper):
             A new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If select operation on the PartitionedTableProxy fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -3971,7 +3971,7 @@ class PartitionedTableProxy(JObjectWrapper):
             A new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If select_distinct operation on the PartitionedTableProxy fails.
         """
         try:
             formulas = to_sequence(formulas)
@@ -4008,7 +4008,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If natural_join operation on the PartitionedTableProxy fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -4047,7 +4047,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If exact_join operation on the PartitionedTableProxy fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -4090,7 +4090,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If join operation on the PartitionedTableProxy fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -4134,7 +4134,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If as-of join operation on the PartitionedTableProxy fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -4176,7 +4176,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If reverse as-of join operation on the PartitionedTableProxy fails.
         """
         try:
             on = ",".join(to_sequence(on))
@@ -4207,7 +4207,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If group-by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4240,7 +4240,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If agg_by operation on the PartitionedTableProxy fails.
         """
         try:
             aggs = to_sequence(aggs)
@@ -4276,7 +4276,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If agg_all_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4307,7 +4307,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If count_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4339,7 +4339,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If first_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4369,7 +4369,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If last_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4397,7 +4397,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If min_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4425,7 +4425,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If max_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4453,7 +4453,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If sum_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4481,7 +4481,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If sum_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4513,7 +4513,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If sum_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4545,7 +4545,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If avg_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4575,7 +4575,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If avg_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4605,7 +4605,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If median_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4635,7 +4635,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If std_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4663,7 +4663,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If var_by operation on the PartitionedTableProxy fails.
         """
         try:
             by = to_sequence(by)
@@ -4694,7 +4694,7 @@ class PartitionedTableProxy(JObjectWrapper):
             a new PartitionedTableProxy
 
         Raises:
-            DHError
+            DHError: If update-by operation on the PartitionedTableProxy fails.
         """
         try:
             ops = to_sequence(ops)
@@ -4738,7 +4738,7 @@ class MultiJoinInput(JObjectWrapper):
                 table, can be renaming expressions, i.e. "new_col = col"; default is None
 
         Raises:
-            DHError
+            DHError: If unable to build a MultiJoinInput object.
         """
         try:
             self.table = table
@@ -4779,7 +4779,7 @@ class MultiJoinTable(JObjectWrapper):
                 When MultiJoinInput objects are supplied, this parameter must be omitted.
 
         Raises:
-            DHError
+            DHError: If unable to build a MultiJoinTable object.
         """
         try:
             if isinstance(input, Table) or (
@@ -4878,7 +4878,7 @@ def table_diff(
         string
 
     Raises:
-        DHError
+        DHError: If table diff fails.
     """
     try:
         diff_items = []
@@ -4985,7 +4985,7 @@ def keyed_transpose(
         a new table
 
     Raises:
-        DHError
+        DHError: If keyed_transpose operation fails.
     """
     try:
         j_source_table = unwrap(table)
@@ -5041,7 +5041,7 @@ class TailInitializationFilter:
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to apply tail initialization filter.
         """
         try:
             j_duration = to_j_duration(period)
@@ -5069,7 +5069,7 @@ class TailInitializationFilter:
             a new Table
 
         Raises:
-            DHError
+            DHError: If unable to apply tail initialization filter.
         """
         try:
             with auto_locking_ctx(table):

--- a/py/server/deephaven/table_factory.py
+++ b/py/server/deephaven/table_factory.py
@@ -71,7 +71,7 @@ def empty_table(size: int) -> Table:
          a Table
 
     Raises:
-        DHError
+        DHError: If unable to create an empty table.
     """
     try:
         return Table(j_table=_JTableTools.emptyTable(size))
@@ -99,7 +99,7 @@ def time_table(
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to create a time table.
     """
     try:
         builder = _JTableTools.timeTableBuilder()
@@ -136,7 +136,7 @@ def new_table(cols: Union[Sequence[InputColumn], Mapping[str, Sequence]]) -> Tab
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to create a new table.
     """
     try:
         if isinstance(cols, Mapping):
@@ -163,7 +163,7 @@ def merge(tables: Sequence[Table]) -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If merging the tables fails.
     """
     try:
         with auto_locking_ctx(*tables):
@@ -185,7 +185,7 @@ def merge_sorted(tables: Sequence[Table], order_by: str) -> Table:
          a Table
 
     Raises:
-        DHError
+        DHError: If merging the sorted tables fails.
     """
     try:
         with auto_locking_ctx(*tables):
@@ -211,7 +211,7 @@ class DynamicTableWriter(JObjectWrapper):
             col_defs(dict[str, DTypes]): a map of column names and types of the new table
 
         Raises:
-            DHError
+            DHError: If unable to create a DynamicTableWriter.
         """
         col_names = list(col_defs.keys())
         col_dtypes = list(col_defs.values())
@@ -237,7 +237,7 @@ class DynamicTableWriter(JObjectWrapper):
         """Closes the writer.
 
         Raises:
-            DHError
+            DHError: If unable to close the writer.
         """
         try:
             self._j_table_writer.close()
@@ -255,7 +255,7 @@ class DynamicTableWriter(JObjectWrapper):
                 of the table
 
         Raises:
-            DHError
+            DHError: If unable to write a row.
         """
         try:
             values = tuple(to_sequence(values))
@@ -289,7 +289,7 @@ class InputTable(Table):
             table (Table): the table that provides the rows to write
 
         Raises:
-            DHError
+            DHError: If adding to the InputTable fails.
         """
         try:
             self.j_input_table.add(table.j_table)
@@ -304,7 +304,7 @@ class InputTable(Table):
             table (Table): the table with the keys to delete
 
         Raises:
-            DHError
+            DHError: If deleting data from the InputTable fails.
         """
         try:
             self.j_input_table.delete(table.j_table)
@@ -335,7 +335,7 @@ class InputTable(Table):
                 will not be further processed by the server.
 
         Raises:
-            DHError
+            DHError: If asynchronously adding to the InputTable fails.
         """
         try:
             if on_error:
@@ -380,7 +380,7 @@ class InputTable(Table):
                 will not be further processed by the server.
 
         Raises:
-            DHError
+            DHError: If asynchronously deleting data from the InputTable fails.
         """
         try:
             if on_error:
@@ -434,7 +434,7 @@ def input_table(
         an InputTable
 
     Raises:
-        DHError
+        DHError: If unable to create an in-memory InputTable.
     """
 
     try:
@@ -477,7 +477,7 @@ def ring_table(parent: Table, capacity: int, initialize: bool = True) -> Table:
         a Table
 
     Raises:
-        DHError
+        DHError: If unable to create a ring table.
     """
     try:
         return Table(j_table=_JRingTableTools.of(parent.j_table, capacity, initialize))
@@ -528,7 +528,7 @@ def function_generated_table(
         a new table
 
     Raises:
-        DHError
+        DHError: If neither refresh_interval_ms nor source_tables is provided.
     """
     if refresh_interval_ms is None and source_tables is None:
         raise DHError("Either refresh_interval_ms or source_tables must be provided!")

--- a/py/server/deephaven/table_listener.py
+++ b/py/server/deephaven/table_listener.py
@@ -352,7 +352,7 @@ class TableListenerHandle(JObjectWrapper):
                 will be logged in the Deephaven server log and will not be further processed by the server.
 
         Raises:
-            DHError
+            DHError: If unable to create a table listener.
         """
         if not t.is_refreshing:
             raise DHError(message="table must be a refreshing table.")
@@ -403,7 +403,7 @@ class TableListenerHandle(JObjectWrapper):
             do_replay (bool): whether to replay the initial snapshot of the table, default is False
 
         Raises:
-            DHError
+            DHError: If unable to listen to the table changes.
         """
         if self.started:
             raise RuntimeError("Attempting to start an already started listener..")
@@ -472,7 +472,7 @@ def listen(
         a TableListenerHandle
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     table_listener_handle = TableListenerHandle(
         t=t,
@@ -599,7 +599,7 @@ class MergedListenerHandle(JObjectWrapper):
                 will be logged in the Deephaven server log and will not be further processed by the server.
 
         Raises:
-            DHError
+            DHError: If unable to create a merged listener adapter.
         """
         if len(tables) < 2:
             raise DHError(
@@ -660,7 +660,7 @@ class MergedListenerHandle(JObjectWrapper):
             do_replay (bool): whether to replay the initial snapshots of the tables, default is False
 
         Raises:
-            DHError
+            DHError: If unable to listen to the table changes.
         """
         if self.started:
             raise RuntimeError(
@@ -753,7 +753,7 @@ def merged_listen(
         a MergedListenerHandle
 
     Raises:
-        DHError
+        DHError: If the operation fails.
     """
     merged_listener_handle = MergedListenerHandle(
         tables=tables,

--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -164,7 +164,8 @@ def dh_now(system: bool = False, resolution: Literal["ns", "ms"] = "ns") -> Inst
         Instant
 
     Raises:
-        DHError, TypeError
+        DHError: If getting the current time fails.
+        TypeError: If the time resolution is not supported.
     """
     try:
         if resolution == "ns":
@@ -202,7 +203,7 @@ def dh_today(tz: Optional[TimeZone] = None) -> str:
         Date string
 
     Raises:
-        DHError
+        DHError: If getting today's date fails.
     """
     try:
         if tz is None:
@@ -224,7 +225,7 @@ def dh_time_zone() -> TimeZone:
         TimeZone
 
     Raises:
-        DHError
+        DHError: If getting the default time zone fails.
     """
     try:
         return _JDateTimeUtils.timeZone()
@@ -249,7 +250,7 @@ def time_zone_alias_add(alias: str, tz: str) -> None:
         None
 
     Raises:
-        DHError
+        DHError: If adding the time zone alias fails.
     """
     try:
         return _JDateTimeUtils.timeZoneAliasAdd(alias, tz)
@@ -267,7 +268,7 @@ def time_zone_alias_rm(alias: str) -> bool:
         True if the alias was present; False if the alias was not present.
 
     Raises:
-        DHError
+        DHError: If removing the time zone alias fails.
     """
     try:
         return _JDateTimeUtils.timeZoneAliasRm(alias)
@@ -360,7 +361,8 @@ def to_j_time_zone(tz: Optional[TimeZoneLike]) -> Optional[TimeZone]:
         TimeZone
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a TimeZone.
     """
     try:
         if tz is None or pandas.isnull(tz):  # type: ignore[arg-type]
@@ -402,7 +404,8 @@ def to_j_local_date(dt: Optional[LocalDateLike]) -> Optional[LocalDate]:
         LocalDate
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a LocalDate.
     """
 
     try:
@@ -447,7 +450,8 @@ def to_j_local_time(dt: Optional[LocalTimeLike]) -> Optional[LocalTime]:
         LocalTime
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a LocalTime.
     """
 
     try:
@@ -503,7 +507,7 @@ def to_j_instant(dt: Optional[InstantLike]) -> Optional[Instant]:
         Instant, TypeError
 
     Raises:
-        DHError
+        DHError: If converting to a Java time value fails.
     """
     try:
         if dt is None or pandas.isnull(dt):
@@ -554,7 +558,8 @@ def to_j_zdt(dt: Optional[ZonedDateTimeLike]) -> Optional[ZonedDateTime]:
         ZonedDateTime
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a ZonedDateTime.
     """
     try:
         if dt is None or pandas.isnull(dt):
@@ -615,7 +620,8 @@ def to_j_duration(dt: Optional[DurationLike]) -> Optional[Duration]:
         Duration
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a Duration.
     """
     try:
         if dt is None or pandas.isnull(dt):
@@ -669,7 +675,9 @@ def to_j_period(dt: Optional[PeriodLike]) -> Optional[Period]:
         Period
 
     Raises:
-        DHError, TypeError, ValueError
+        DHError: If converting to a Java time value fails.
+        TypeError: If the value cannot be converted to a Period.
+        ValueError: If the period is not days or weeks.
     """
     try:
         if dt is None or pandas.isnull(dt):
@@ -751,7 +759,8 @@ def to_date(dt: Union[None, LocalDate, ZonedDateTime]) -> Optional[datetime.date
         datetime.date
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to datetime.date.
     """
     try:
         if dt is None:
@@ -788,7 +797,8 @@ def to_time(dt: Union[None, LocalTime, ZonedDateTime]) -> Optional[datetime.time
         datetime.time
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to datetime.time.
     """
     try:
         if dt is None:
@@ -825,7 +835,8 @@ def to_datetime(dt: Union[None, Instant, ZonedDateTime]) -> Optional[datetime.da
         datetime.datetime
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to datetime.datetime.
     """
     try:
         if dt is None:
@@ -862,7 +873,8 @@ def to_pd_timestamp(
         pandas.Timestamp
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to pandas.Timestamp.
     """
     try:
         if dt is None:
@@ -894,7 +906,8 @@ def to_np_datetime64(
         numpy.datetime64
 
     Raises:
-        DHError, TypeError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to datetime.datetime.
     """
     try:
         if dt is None:
@@ -928,7 +941,9 @@ def to_timedelta(dt: Union[None, Duration]) -> Optional[datetime.timedelta]:
         datetime.timedelta
 
     Raises:
-        DHError, TypeError, ValueError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to datetime.timedelta.
+        ValueError: If the period is not days or weeks.
     """
     try:
         if dt is None:
@@ -972,7 +987,9 @@ def to_pd_timedelta(dt: Union[None, Duration]) -> Optional[pandas.Timedelta]:
         pandas.Timedelta
 
     Raises:
-        DHError, TypeError, ValueError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to pandas.Timedelta.
+        ValueError: If the period is not days or weeks.
     """
     try:
         if dt is None:
@@ -1019,7 +1036,9 @@ def to_np_timedelta64(dt: Union[None, Duration, Period]) -> Optional[numpy.timed
         numpy.timedelta64
 
     Raises:
-        DHError, TypeError, ValueError
+        DHError: If converting to a Python time value fails.
+        TypeError: If the value cannot be converted to numpy.timedelta64.
+        ValueError: If the period is not days, months, or years.
     """
     try:
         if dt is None:
@@ -1085,7 +1104,7 @@ def simple_date_format(pattern: str) -> jpy.JType:
         JObject
 
     Raises:
-        DHError
+        DHError: If creating the date format fails.
     """
     try:
         # Returning a Java object directly to avoid Python/Java boundary crossings in query strings

--- a/py/server/deephaven/updateby.py
+++ b/py/server/deephaven/updateby.py
@@ -92,7 +92,7 @@ class OperationControl(JObjectWrapper):
                 (Java BigDecimal/BigInteger), default is DECIMAL128.
 
         Raises:
-            DHError
+            DHError: If unable to build an OperationControl object.
         """
         try:
             j_builder = _JOperationControl.builder()
@@ -144,7 +144,7 @@ def ema_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a tick-decay EMA UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -191,7 +191,7 @@ def ema_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a time-decay EMA UpdateByOperation.
     """
     try:
         decay_time = (
@@ -239,7 +239,7 @@ def ems_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a tick-decay EMS UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -286,7 +286,7 @@ def ems_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a time-decay EMS UpdateByOperation.
     """
     try:
         decay_time = (
@@ -334,7 +334,7 @@ def emmin_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a tick-decay EM Min UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -383,7 +383,7 @@ def emmin_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a time-decay EM Min UpdateByOperation.
     """
     try:
         decay_time = (
@@ -433,7 +433,7 @@ def emmax_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a tick-decay EM Max UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -482,7 +482,7 @@ def emmax_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a time-decay EM Max UpdateByOperation.
     """
     try:
         decay_time = (
@@ -532,7 +532,7 @@ def emstd_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a tick-decay EM Std UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -582,7 +582,7 @@ def emstd_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a time-decay EM Std UpdateByOperation.
     """
     try:
         decay_time = (
@@ -620,7 +620,7 @@ def cum_sum(cols: Union[str, Sequence[str]]) -> UpdateByOperation:
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a cumulative sum UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -641,7 +641,7 @@ def cum_prod(cols: Union[str, Sequence[str]]) -> UpdateByOperation:
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a cumulative product UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -664,7 +664,7 @@ def cum_min(cols: Union[str, Sequence[str]]) -> UpdateByOperation:
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a cumulative minimum UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -687,7 +687,7 @@ def cum_max(cols: Union[str, Sequence[str]]) -> UpdateByOperation:
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a cumulative maximum UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -713,7 +713,7 @@ def cum_count_where(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a cumulative count_where UpdateByOperation.
     """
     if not isinstance(col, str):
         raise DHError(
@@ -743,7 +743,7 @@ def forward_fill(cols: Union[str, Sequence[str]]) -> UpdateByOperation:
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a forward fill UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -776,7 +776,7 @@ def delta(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a delta UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -818,7 +818,7 @@ def rolling_sum_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling sum (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -869,7 +869,7 @@ def rolling_sum_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling sum (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -924,7 +924,7 @@ def rolling_group_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling group (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -975,7 +975,7 @@ def rolling_group_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling group (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1030,7 +1030,7 @@ def rolling_avg_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling average (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1081,7 +1081,7 @@ def rolling_avg_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling average (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1136,7 +1136,7 @@ def rolling_min_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling minimum (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1187,7 +1187,7 @@ def rolling_min_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling minimum (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1242,7 +1242,7 @@ def rolling_max_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling maximum (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1293,7 +1293,7 @@ def rolling_max_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling maximum (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1348,7 +1348,7 @@ def rolling_prod_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling product (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1401,7 +1401,7 @@ def rolling_prod_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling product (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1456,7 +1456,7 @@ def rolling_count_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling count (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1507,7 +1507,7 @@ def rolling_count_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling count (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1565,7 +1565,7 @@ def rolling_std_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling standard deviation (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1619,7 +1619,7 @@ def rolling_std_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling standard deviation (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1675,7 +1675,7 @@ def rolling_wavg_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling weighted average (tick) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1730,7 +1730,7 @@ def rolling_wavg_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling weighted average (time) UpdateByOperation.
     """
     try:
         cols = to_sequence(cols)
@@ -1812,7 +1812,7 @@ def rolling_formula_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling formula (tick) UpdateByOperation.
     """
     try:
         if formula_param is None:
@@ -1897,7 +1897,7 @@ def rolling_formula_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling formula (time) UpdateByOperation.
     """
     try:
         rev_time = (
@@ -1965,7 +1965,7 @@ def rolling_count_where_tick(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling count_where UpdateByOperation.
     """
     if not isinstance(col, str):
         raise DHError(
@@ -2025,7 +2025,7 @@ def rolling_count_where_time(
         an UpdateByOperation
 
     Raises:
-        DHError
+        DHError: If unable to create a rolling count_where UpdateByOperation.
     """
     if not isinstance(col, str):
         raise DHError(

--- a/py/server/deephaven/uri.py
+++ b/py/server/deephaven/uri.py
@@ -26,7 +26,7 @@ def resolve(uri: str) -> Any:
         an object
 
     Raises:
-        DHError
+        DHError: If unable to resolve the URI.
     """
 
     try:

--- a/py/server/deephaven_internal/jvm/__init__.py
+++ b/py/server/deephaven_internal/jvm/__init__.py
@@ -17,7 +17,7 @@ def check_ready():
     Raises a RuntimeError if the JVM is not ready.
 
     Raises:
-        RuntimeError
+        RuntimeError: If the Deephaven Server has not been initialized. Please ensure that deephaven_server.Server has been constructed before importing deephaven.
     """
     # Note: we might be tempted to store the source of truth for this in Java, but we aren't able to do that.
     # `import jpy` has potential side effects, and may improperly start the JVM.
@@ -33,7 +33,7 @@ def check_py_env():
     """Checks if the current Python environment is in good order and if not, raises a RuntimeError.
 
     Raises:
-        RuntimeError
+        RuntimeError: If the Deephaven Enterprise Python Package (name 'deephaven' on pypi) is installed in the current Python environment. It conflicts with the Deephaven Community Python Package (name 'deephaven-core' on pypi). Please uninstall the 'deephaven' package and reinstall the 'deephaven-core' package.
     """
     import importlib.metadata
 
@@ -64,7 +64,7 @@ def init_jvm(*args, **kwargs):
     Calls ready() after jpyutil.init_jvm(...).
 
     Raises:
-        ImportError
+        ImportError: If unable to initialize JVM, try setting the environment variable JAVA_HOME (JDK 11+ required).
     """
     # Note: we might be able to use our own logic instead of jpyutil here in the future
     import jpyutil


### PR DESCRIPTION
Google-style docstring parsers skip a Raises entry that is only a type name, so autocomplete never shows it.

I added a short description after each Raises exception in the Python server API. Existing descriptions are unchanged.

Closes #6164
