### PR TITLE
chore: no-ticket: bump actions/setup-java from v5 to v6

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -141,7 +141,7 @@ jobs:
             type=ref,event=branch
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -51,7 +51,7 @@ jobs:
           lfs: true
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -312,7 +312,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -383,7 +383,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -438,7 +438,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -42,7 +42,7 @@ jobs:
           lfs: true
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -141,7 +141,7 @@ jobs:
           merge-multiple: true
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: .github/scripts/check-gitignore-rules.sh
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/tag-base-images.yml
+++ b/.github/workflows/tag-base-images.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup JDKs
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |


### PR DESCRIPTION
All usages only set `distribution: temurin` and `java-version`, which are unaffected by v6's breaking changes (removal of legacy Adopt distributions, renamed jdk-file/env-var inputs). Note v6 now defaults `verify-signature: true` for Temurin downloads, a new behavior to be aware of if a setup step ever fails on signature verification.