### PR TITLE
chore: no-ticket: bump actions/checkout from v5 to v7

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get Semver
         id: semver

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -19,7 +19,7 @@ jobs:
       # Must checkout for push, but not pull_request according to the action
       - name: Checkout
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v4
@@ -46,7 +46,7 @@ jobs:
         run: df -h
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           lfs: true
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -62,7 +62,7 @@ jobs:
       group: core-docs-check-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with: # Does not need lfs to validate since the header file existing is enough for the check
           sparse-checkout: /docs/
           sparse-checkout-cone-mode: false
@@ -84,7 +84,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           sparse-checkout: /docs/
           sparse-checkout-cone-mode: false
@@ -126,7 +126,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -178,7 +178,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -230,7 +230,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -309,7 +309,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -380,7 +380,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5
@@ -435,7 +435,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/docs-sync-check.yml
+++ b/.github/workflows/docs-sync-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Check Documentation Labels
         env:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Check Release Notes Labels
         env:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     if: ${{ github.repository_owner == 'deephaven' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: df -h
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           lfs: true
 

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository_owner == 'deephaven' # Don't run on forks that haven't disabled actions
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           sparse-checkout: /docs/
           sparse-checkout-cone-mode: false
@@ -33,7 +33,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository_owner == 'deephaven' # Don't run on forks that haven't disabled actions
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         sparse-checkout: /docs/
         sparse-checkout-cone-mode: false

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.repository_owner == 'deephaven' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/pr-merge-webhook.yml
+++ b/.github/workflows/pr-merge-webhook.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Trigger PR Merge Webhook
         env:

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -19,7 +19,7 @@ jobs:
       # Must checkout for push, but not pull_request according to the action
       - name: Checkout
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v4
@@ -48,7 +48,7 @@ jobs:
         run: df -h
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -19,7 +19,7 @@ jobs:
       # Must checkout for push, but not pull_request according to the action
       - name: Checkout
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v4
@@ -36,7 +36,7 @@ jobs:
     if: ${{ needs.changes.outputs.non-docs == 'true' || startsWith(github.ref, 'refs/heads/release/v') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Check gitignore rules
         run: .github/scripts/check-gitignore-rules.sh
@@ -73,7 +73,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.non-docs == 'true' || startsWith(github.ref, 'refs/heads/release/v') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/tag-base-images.yml
+++ b/.github/workflows/tag-base-images.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup JDKs
         uses: actions/setup-java@v5

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout latest
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: main
           sparse-checkout: |


### PR DESCRIPTION
v6 moves persisted git credentials from .git/config into a separate file under $RUNNER_TEMP; no workflow here parses .git/config or depends on the old location. v7 refuses to check out fork PR code by default on pull_request_target/workflow_run triggers unless allow-unsafe-pr-checkout is set; the only checkout under pull_request_target here (pr-merge-webhook.yml) doesn't override ref to the fork head, and the one workflow that does (docs-pr-preview.yml) is already pinned to v7.0.1 with allow-unsafe-pr-checkout: true, so no further changes are needed there.