### PR TITLE
fix: DH-23529: Add missing open paren in inverted isNaN filter formula

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterAdapter.java
@@ -483,7 +483,7 @@ class WhereFilterAdapter implements Filter.Visitor<WhereFilter> {
 
         private WhereFilter getExpression(String x) {
             // TODO(deephaven-core#3740): Remove engine crutch on io.deephaven.api.Strings
-            return WhereFilterFactory.getExpression((inverted ? "!isNull(" : "isNull(") + x + ")");
+            return WhereFilterFactory.getExpression((inverted ? "!" : "") + "isNull(" + x + ")");
         }
 
         @Override
@@ -544,7 +544,7 @@ class WhereFilterAdapter implements Filter.Visitor<WhereFilter> {
 
         private WhereFilter getExpression(String x) {
             // TODO(deephaven-core#3740): Remove engine crutch on io.deephaven.api.Strings
-            return WhereFilterFactory.getExpression((inverted ? "!isNaN(" : "isNaN(") + x + ")");
+            return WhereFilterFactory.getExpression((inverted ? "!" : "") + "isNaN(" + x + ")");
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterAdapter.java
@@ -544,7 +544,7 @@ class WhereFilterAdapter implements Filter.Visitor<WhereFilter> {
 
         private WhereFilter getExpression(String x) {
             // TODO(deephaven-core#3740): Remove engine crutch on io.deephaven.api.Strings
-            return WhereFilterFactory.getExpression((inverted ? "!isNaN" : "isNaN(") + x + ")");
+            return WhereFilterFactory.getExpression((inverted ? "!isNaN(" : "isNaN(") + x + ")");
         }
 
         @Override

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereSpecialCasesTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereSpecialCasesTest.java
@@ -1638,6 +1638,18 @@ public class QueryTableWhereSpecialCasesTest {
                 "doubleCol",
                 RawString.of("doubleCol in NaN"),
                 val -> Double.isNaN(val));
+
+        // A non-ColumnName expression cannot use the MatchFilter fast path; it is compiled as a formula instead.
+        validateFloatFilter(
+                source,
+                "floatCol",
+                Filter.isNaN(RawString.of("floatCol + 0.0f")),
+                val -> Float.isNaN(val));
+        validateDoubleFilter(
+                source,
+                "doubleCol",
+                Filter.isNaN(RawString.of("doubleCol + 0.0")),
+                val -> Double.isNaN(val));
     }
 
     @Test
@@ -1655,6 +1667,18 @@ public class QueryTableWhereSpecialCasesTest {
                 source,
                 "doubleCol",
                 Filter.isNotNaN(ColumnName.of("doubleCol")),
+                val -> !Double.isNaN(val));
+
+        // A non-ColumnName expression cannot use the MatchFilter fast path; it is compiled as a formula instead.
+        validateFloatFilter(
+                source,
+                "floatCol",
+                Filter.isNotNaN(RawString.of("floatCol + 0.0f")),
+                val -> !Float.isNaN(val));
+        validateDoubleFilter(
+                source,
+                "doubleCol",
+                Filter.isNotNaN(RawString.of("doubleCol + 0.0")),
                 val -> !Double.isNaN(val));
     }
 


### PR DESCRIPTION
`ExpressionIsNaNAdapter.getExpression()` omitted the opening parenthesis on the inverted branch, so `!isNaN` over a non-`ColumnName` expression produced a malformed formula. `Filter.isNotNaN(RawString.of("A + B"))` built `"!isNaNA + B)"` and threw `FormulaCompilationException`.

Only non-column expressions (`RawString`, `Function`, `Method`, `Literal`, nested `Filter`) reach this path — `visit(ColumnName)` returns a `MatchFilter` with `nanMatch`, so column-based `isNaN`/`isNotNaN` filters were never affected. The sibling `ExpressionIsNullAdapter` was already correct.

Present since v41.0. The failure is a hard compilation error rather than a wrong result, so no query has silently returned bad data.

Also extends `testFilterIsNaN` / `testFilterIsNotNaN` to cover the expression path. Every existing case passed a `ColumnName` and therefore exercised only the `MatchFilter` fast path, which is why the inverted formula branch had no coverage.
