### PR TITLE
docs: DOC-1180: Add missing links to JS API Javadocs

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/Column.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/Column.java
@@ -39,7 +39,7 @@ public class Column {
     private final int jsIndex;
 
     /**
-     * Specific to rollup tables when constituent columns are enabled. Used in {@code toString()}, but ignored for
+     * Specific to rollup tables when constituent columns are enabled. Used in {@link #toString()}, but ignored for
      * equals/hashcode, since it might be helpful for debugging, but could potentially confuse some comparisons between
      * instances since this is set after the CTS is created, ready for use.
      */
@@ -51,8 +51,8 @@ public class Column {
     private final JsArray<ColumnRestriction> columnRestrictions;
 
     /**
-     * Format entire rows colors using the expression specified. Returns a {@code CustomColumn} object to apply to a
-     * table using {@code applyCustomColumns} with the parameters specified.
+     * Format entire rows colors using the expression specified. Returns a {@link CustomColumn} object to apply to a
+     * table using {@link JsTable#applyCustomColumns(JsArray) applyCustomColumns} with the parameters specified.
      *
      * @param expression
      * @param options
@@ -65,7 +65,8 @@ public class Column {
     }
 
     /**
-     * A {@code CustomColumn} object to apply using {@code applyCustomColumns} with the expression specified.
+     * A {@link CustomColumn} object to apply using {@link JsTable#applyCustomColumns(JsArray) applyCustomColumns} with
+     * the expression specified.
      *
      * @param name
      * @param expression
@@ -99,7 +100,8 @@ public class Column {
     }
 
     /**
-     * The value for this column in the given row. Type will be consistent with the type of the Column.
+     * The value for this column in the given {@link TableData.Row}. Type will be consistent with the {@link #getType()
+     * type} of the Column.
      *
      * @param row
      * @return Any
@@ -115,7 +117,8 @@ public class Column {
     }
 
     /**
-     * @deprecated Do not use. Internal index of the column in the table, to be used as a key on the Row.
+     * @deprecated Do not use. Internal index of the column in the table, to be used as a key on the
+     *             {@link TableData.Row}.
      * @return int
      */
     @Deprecated
@@ -168,7 +171,8 @@ public class Column {
 
     /**
      * If this column is part of a roll-up tree table, represents the type of the row data that can be found in this
-     * column for leaf nodes if {@code includeConstituents} is enabled. Otherwise, it is {@code null}.
+     * column for leaf nodes if {@link io.deephaven.web.client.api.tree.JsRollupConfig RollupConfig.includeConstituents}
+     * is enabled. Otherwise, it is {@code null}.
      *
      * @return String
      */
@@ -192,7 +196,7 @@ public class Column {
 
     /**
      * {@code true} if this column is a partition column. Partition columns are used for filtering uncoalesced tables -
-     * see {@link JsTable#isUncoalesced()}.
+     * see {@link JsTable Table.isUncoalesced}.
      *
      * @return {@code true} if the column is a partition column.
      */
@@ -225,11 +229,12 @@ public class Column {
     }
 
     /**
-     * Returns the column restrictions for input table columns, or an empty array if this is not an input table column
-     * or if no restrictions are defined. The restrictions are implementation-specific constraints that the server
-     * enforces on column values. The returned array is a copy and may be safely modified by the caller.
+     * Returns the column restrictions for {@link io.deephaven.web.client.api.input.JsInputTable input table} columns,
+     * or an empty array if this is not an input table column or if no restrictions are defined. The restrictions are
+     * implementation-specific constraints that the server enforces on column values. The returned array is a copy and
+     * may be safely modified by the caller.
      *
-     * @return Array of column restrictions, empty if none are defined
+     * @return Array of {@link ColumnRestriction}, empty if none are defined
      */
     @JsProperty
     public JsArray<ColumnRestriction> getColumnRestrictions() {
@@ -248,7 +253,8 @@ public class Column {
     }
 
     /**
-     * A {@code CustomColumn} object to apply using {@code applyCustomColumns} with the expression specified.
+     * A {@link CustomColumn} object to apply using {@link JsTable#applyCustomColumns(JsArray) applyCustomColumns} with
+     * the expression specified.
      *
      * @param expression
      * @return {@link CustomColumn}
@@ -260,7 +266,8 @@ public class Column {
     }
 
     /**
-     * A {@code CustomColumn} object to apply using {@code applyCustomColumns} with the expression specified.
+     * A {@link CustomColumn} object to apply using {@link JsTable#applyCustomColumns(JsArray) applyCustomColumns} with
+     * the expression specified.
      *
      * @param expression
      * @return {@link CustomColumn}
@@ -272,7 +279,8 @@ public class Column {
     }
 
     /**
-     * A {@code CustomColumn} object to apply using {@code applyCustomColumns} with the expression specified.
+     * A {@link CustomColumn} object to apply using {@link JsTable#applyCustomColumns(JsArray) applyCustomColumns} with
+     * the expression specified.
      *
      * @param expression
      * @return {@link CustomColumn}

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -36,10 +36,11 @@ import static io.deephaven.web.client.api.JsTable.EVENT_ROWUPDATED;
 
 /**
  * This object serves as a "handle" to a subscription, allowing it to be acted on directly or canceled outright. If you
- * retain an instance of this, you have two choices - either only use it to call {@code close} on it to stop the table's
- * viewport without creating a new one, or listen directly to this object instead of the table for data events, and
- * always call {@code close} when finished. Calling any method on this object other than {@code close} will result in it
- * continuing to live on after {@code setViewport} is called on the original table, or after the table is modified.
+ * retain an instance of this, you have two choices - either only use it to call {@link #close()} on it to stop the
+ * {@link JsTable table}'s viewport without creating a new one, or listen directly to this object instead of the table
+ * for data events, and always call {@link #close()} when finished. Calling any method on this object other than
+ * {@link #close()} will result in it continuing to live on after {@link JsTable#setViewport(double, double)
+ * setViewport} is called on the original table, or after the table is modified.
  */
 @TsName(namespace = "dh")
 public class TableViewportSubscription extends AbstractTableSubscription {
@@ -193,8 +194,8 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     }
 
     /**
-     * Utility to fire an event on this object and also optionally on the parent if still active. All {@code fireEvent}
-     * overloads dispatch to this.
+     * Utility to fire an event on this object and also optionally on the parent if still active. All
+     * {@link #fireEvent(Event)} overloads dispatch to this.
      *
      * @param e The event to fire.
      * @param <T> The type of the custom event data.
@@ -217,7 +218,8 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     }
 
     /**
-     * Changes the rows and columns set on this viewport. This cannot be used to change the update interval.
+     * Changes the rows and {@link Column columns} set on this viewport. This cannot be used to change the update
+     * interval.
      * 
      * @param firstRow
      * @param lastRow
@@ -237,7 +239,7 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     /**
      * Update the options for this viewport subscription. This cannot alter the update interval or preview options.
      * 
-     * @param options The subscription options.
+     * @param options The subscription options; see {@link DataOptions.ViewportSubscriptionOptions} for details.
      */
     @JsMethod
     public void update(@TsTypeRef(DataOptions.ViewportSubscriptionOptions.class) Object options) {
@@ -310,7 +312,7 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     }
 
     /**
-     * Stops this viewport from running, stopping all events on itself and on the table that created it.
+     * Stops this viewport from running, stopping all events on itself and on the {@link JsTable table} that created it.
      */
     @JsMethod
     public void close() {
@@ -324,8 +326,8 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     }
 
     /**
-     * Internal API method to indicate that the {@code Table} itself has no further use for this. The subscription
-     * should stop forwarding events and optionally close the underlying table/subscription.
+     * Internal API method to indicate that the {@link JsTable Table} itself has no further use for this. The
+     * subscription should stop forwarding events and optionally close the underlying table/subscription.
      */
     public void internalClose() {
         // indicate that the base table shouldn't get events anymore, even if it is still retained elsewhere
@@ -343,7 +345,7 @@ public class TableViewportSubscription extends AbstractTableSubscription {
     }
 
     /**
-     * Gets the data currently visible in this viewport
+     * Gets the data currently visible in this viewport, as a {@link ViewportData}.
      * 
      * @return Promise of {@link TableData}.
      */

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsRollupConfig.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsRollupConfig.java
@@ -29,8 +29,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Describes a grouping and aggregations for a roll-up table. Pass to the {@code Table.rollup} function to create a
- * roll-up table.
+ * Describes a grouping and aggregations for a roll-up table. Pass to the
+ * {@link io.deephaven.web.client.api.JsTable#rollup(Object) Table.rollup} function to create a roll-up
+ * {@link JsTreeTable TreeTable}.
  */
 @JsType(name = "RollupConfig", namespace = "dh")
 public class JsRollupConfig {
@@ -40,17 +41,18 @@ public class JsRollupConfig {
      */
     public JsArray<String> groupingColumns = null;
     /**
-     * Mapping from each aggregation name to the ordered list of columns it should be applied to in the resulting
-     * roll-up table.
+     * Mapping from each {@link JsAggregationOperation AggregationOperation} name to the ordered list of columns it
+     * should be applied to in the resulting roll-up table.
      */
     public JsPropertyMap<JsArray<String>> aggregations =
             Js.cast(JsObject.create(null));
     /**
      * Optional parameter indicating if an extra leaf node should be added at the bottom of the hierarchy, showing the
      * rows in the underlying table which make up that grouping. Since these values might be a different type from the
-     * rest of the column, any client code must check if {@code TreeRow.hasChildren} = {@code false}, and if so,
-     * interpret those values as if they were {@code Column.constituentType} instead of {@code Column.type}. Defaults to
-     * {@code false}.
+     * rest of the column, any client code must check if {@link TreeViewportData.TreeRow#hasChildren()
+     * TreeRow.hasChildren} = {@code false}, and if so, interpret those values as if they were
+     * {@link Column#getConstituentType() Column.constituentType} instead of {@link Column#getType() Column.type}.
+     * Defaults to {@code false}.
      */
     public boolean includeConstituents = false;
     @JsNullable

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/JsBusinessPeriod.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/JsBusinessPeriod.java
@@ -9,7 +9,7 @@ import io.deephaven.proto.backplane.script.grpc.FigureDescriptor;
 import jsinterop.annotations.JsProperty;
 
 /**
- * A business period within a {@code dh.calendar.BusinessCalendar}.
+ * A business period within a {@link JsBusinessCalendar dh.calendar.BusinessCalendar}.
  * <p>
  * A business period describes the open and close times for a single contiguous range of time on a business day.
  */

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/enums/JsDayOfWeek.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/enums/JsDayOfWeek.java
@@ -9,7 +9,7 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
 
 /**
- * String enum values for {@code dh.calendar.DayOfWeek}.
+ * String enum values for {@link DayOfWeek dh.calendar.DayOfWeek}.
  *
  * Instances are represented as strings like {@link #MONDAY}. Use {@link #values()} to get the list of all supported
  * values.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/enums/JsDayOfWeek.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/enums/JsDayOfWeek.java
@@ -9,7 +9,7 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
 
 /**
- * String enum values for {@link DayOfWeek dh.calendar.DayOfWeek}.
+ * String enum values for {@link JsDayOfWeek dh.calendar.DayOfWeek}.
  *
  * Instances are represented as strings like {@link #MONDAY}. Use {@link #values()} to get the list of all supported
  * values.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsAxis.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsAxis.java
@@ -17,8 +17,8 @@ import jsinterop.annotations.*;
 import jsinterop.base.Js;
 
 /**
- * Defines one axis used by series. These instances will be found both on the Chart and the Series instances, and may be
- * shared between Series instances.
+ * Defines one axis used by series. These instances will be found both on the {@link JsChart Chart} and the
+ * {@link JsSeries Series} instances, and may be shared between {@link JsSeries Series} instances.
  */
 @TsInterface
 @TsName(namespace = "dh.plot", name = "Axis")
@@ -46,8 +46,7 @@ public class JsAxis {
      * The calendar with the business hours and holidays to transform plot data against. Defaults to null, or no
      * transform.
      * 
-     * @return dh.calendar.BusinessCalendar
-     *
+     * @return {@link JsBusinessCalendar dh.calendar.BusinessCalendar}
      */
     @JsProperty
     public JsBusinessCalendar getBusinessCalendar() {
@@ -65,7 +64,7 @@ public class JsAxis {
     }
 
     /**
-     * The type for this axis. See {@code AxisFormatType} enum for more details.
+     * The type for this axis. See the {@link JsAxisFormatType AxisFormatType} enum for more details.
      * 
      * @return int
      */
@@ -76,7 +75,8 @@ public class JsAxis {
     }
 
     /**
-     * The type for this axis, indicating how it will be drawn. See {@code AxisType} enum for more details.
+     * The type for this axis, indicating how it will be drawn. See the {@link JsAxisType AxisType} enum for more
+     * details.
      * 
      * @return int
      */
@@ -87,7 +87,7 @@ public class JsAxis {
     }
 
     /**
-     * The position for this axis. See {@code AxisPosition} enum for more details.
+     * The position for this axis. See the {@link JsAxisPosition AxisPosition} enum for more details.
      * 
      * @return int
      */
@@ -129,7 +129,8 @@ public class JsAxis {
     // }
 
     /**
-     * The format pattern to use with this axis. Use the type to determine which type of formatter to use.
+     * The format pattern to use with this axis. Use the {@link #getFormatType() formatType} to determine which type of
+     * formatter to use.
      * 
      * @return String
      */
@@ -212,7 +213,7 @@ public class JsAxis {
      * can be done losslessly. The second two arguments represent the current zoom range of this axis, and if provided,
      * most of the data outside of this range will be filtered out automatically and the visible width mapped to that
      * range. When the UI zooms, pans, or resizes, this method should be called again to update these three values to
-     * ensure that data is correct and current.
+     * ensure that data is correct and current. See {@link JsFigure} for details on how downsampling works.
      *
      * @param pixelCount
      * @param min


### PR DESCRIPTION
Adds missing crosslinks to the JS API Javadocs.