### PR TITLE
chore: Update web version 1.28.1 (#8459)

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=1.27.3
+ARG WEB_VERSION=1.28.1
 ARG GRID_VERSION=1.1.0
 ARG CHART_VERSION=1.1.0
-ARG WIDGET_VERSION=1.27.3
+ARG WIDGET_VERSION=1.28.1
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release notes
https://github.com/deephaven/web-client-ui/releases/tag/v1.28.1


(cherry picked from commit 562f1fdcd002c8b3fcd7ae49661409befc57522c)