### PR TITLE
docs: DOC-1472: Fix accuracy issues in partitioned tables documentation

### DIFF
--- a/docs/groovy/how-to-guides/partitioned-tables.md
+++ b/docs/groovy/how-to-guides/partitioned-tables.md
@@ -303,9 +303,9 @@ resultViaProxy = ptJoined.merge()
 ```
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `naturalJoin`), `whereIn`, or `whereNotIn` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., [`naturalJoin`](../reference/table-operations/join/natural-join.md)), [`whereIn`](../reference/table-operations/filter/where-in.md), or [`whereNotIn`](../reference/table-operations/filter/where-not-in.md) when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
+> When the second argument `sanityCheckJoinOperations` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Why use partitioned tables?
 

--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -259,7 +259,7 @@ trades_updated = pt_trades_updated.merge()
 ```
 
 > [!NOTE]
-> When using a Partitioned Table proxy, you must call `target` to obtain the underlying partitioned table.
+> When using a Partitioned Table proxy, you must access the `target` attribute to obtain the underlying partitioned table.
 
 #### Should I use transform or proxy?
 
@@ -329,9 +329,9 @@ result_via_proxy = pt_joined.merge()
 ```
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `natural_join`), `where_in`, or `where_not_in` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., [`natural_join`](../reference/table-operations/join/natural-join.md)), [`where_in`](../reference/table-operations/filter/where-in.md), or [`where_not_in`](../reference/table-operations/filter/where-not-in.md) when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
+> When the second argument `sanity_check_joins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Why use partitioned tables?
 
@@ -357,7 +357,7 @@ Partitioned tables can improve performance in a couple of different ways.
 #### Parallelization
 
 > [!CAUTION]
-> Python's [Global Interpreter Lock (GIL)](https://docs.python.org/3/glossary.html#term-global-interpreter-lock) prevents threads from running concurrently. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
+> In Python builds that use the [Global Interpreter Lock (GIL)](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), threads cannot run Python code concurrently, unless the Python build is free-threaded. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
 
 Partitioned tables can also improve query performance by parallelizing things that standard tables cannot. Take, for example, an as-of join between two tables. If the tables are partitioned by the exact match columns, then the join operation is done in parallel.
 

--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -357,7 +357,7 @@ Partitioned tables can improve performance in a couple of different ways.
 #### Parallelization
 
 > [!CAUTION]
-> In Python builds that use the [Global Interpreter Lock (GIL)](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), threads cannot run Python code concurrently, unless the Python build is free-threaded. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
+> Python's [Global Interpreter Lock (GIL)](https://docs.python.org/3/glossary.html#term-global-interpreter-lock) prevents threads from running Python code concurrently, unless the Python build is free-threaded. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
 
 Partitioned tables can also improve query performance by parallelizing things that standard tables cannot. Take, for example, an as-of join between two tables. If the tables are partitioned by the exact match columns, then the join operation is done in parallel.
 

--- a/docs/python/reference/table-operations/partitioned-tables/metadata-methods.md
+++ b/docs/python/reference/table-operations/partitioned-tables/metadata-methods.md
@@ -44,10 +44,10 @@ print(partitioned_table.constituent_column)
 
 ## `constituent_tables`
 
-The `constituent_tables` method returns a `PartitionedTable`'s constituent tables as a list of strings.
+The `constituent_tables` method returns a `PartitionedTable`'s current constituent tables as a list of `Table` objects.
 
 ```python syntax
-PartitionedTable.constituent_tables -> List[str]
+PartitionedTable.constituent_tables -> List[Table]
 ```
 
 Here is an example:
@@ -71,6 +71,23 @@ Here is an example:
 
 ```python test-set=1 order=:log
 print(partitioned_table.constituent_table_columns)
+```
+
+## `constituent_table_definition`
+
+The `constituent_table_definition` method returns the table definition shared by all constituent tables of a `PartitionedTable`.
+
+> [!NOTE]
+> All constituent tables in a `PartitionedTable` have the same table definition.
+
+```python syntax
+PartitionedTable.constituent_table_definition -> TableDefinition
+```
+
+Here is an example:
+
+```python test-set=1 order=:log
+print(partitioned_table.constituent_table_definition)
 ```
 
 ## `is_refreshing`
@@ -99,6 +116,20 @@ Here is an example:
 
 ```python test-set=1 order=:log
 print(partitioned_table.key_columns)
+```
+
+## `table`
+
+The `table` method returns the underlying `Table` of a `PartitionedTable`, whose rows contain the constituent tables and key values.
+
+```python syntax
+PartitionedTable.table -> Table
+```
+
+Here is an example:
+
+```python test-set=1 order=:log
+print(partitioned_table.table)
 ```
 
 ## `unique_keys`

--- a/docs/python/reference/table-operations/partitioned-tables/metadata-methods.md
+++ b/docs/python/reference/table-operations/partitioned-tables/metadata-methods.md
@@ -44,7 +44,7 @@ print(partitioned_table.constituent_column)
 
 ## `constituent_tables`
 
-The `constituent_tables` method returns a `PartitionedTable`'s current constituent tables as a list of `Table` objects.
+The `constituent_tables` property returns a `PartitionedTable`'s current constituent tables as a list of `Table` objects.
 
 ```python syntax
 PartitionedTable.constituent_tables -> List[Table]
@@ -75,10 +75,10 @@ print(partitioned_table.constituent_table_columns)
 
 ## `constituent_table_definition`
 
-The `constituent_table_definition` method returns the table definition shared by all constituent tables of a `PartitionedTable`.
+The `constituent_table_definition` property returns a table definition that is either shared by, or mutually compatible with, all constituent tables of a `PartitionedTable`.
 
 > [!NOTE]
-> All constituent tables in a `PartitionedTable` have the same table definition.
+> Mutual compatibility means the returned definition's columns match each constituent's columns by name, data type, and component type — it does not guarantee identical storage or derivation details.
 
 ```python syntax
 PartitionedTable.constituent_table_definition -> TableDefinition
@@ -120,7 +120,7 @@ print(partitioned_table.key_columns)
 
 ## `table`
 
-The `table` method returns the underlying `Table` of a `PartitionedTable`, whose rows contain the constituent tables and key values.
+The `table` property returns the underlying `Table` of a `PartitionedTable`, whose rows contain the constituent tables and key values.
 
 ```python syntax
 PartitionedTable.table -> Table

--- a/docs/python/snapshots/c9b9421b28ad1d896ef6a68af809c3d0.json
+++ b/docs/python/snapshots/c9b9421b28ad1d896ef6a68af809c3d0.json
@@ -1,0 +1,1 @@
+{"file":"reference/table-operations/partitioned-tables/metadata-methods.md","objects":{":log":{"type":"Log","data":"TableDefinition {columns=[ColumnDefinition {name=IntCol, dataType=int, componentType=null, columnType=Normal}, ColumnDefinition {name=StrCol, dataType=class java.lang.String, componentType=null, columnType=Normal}]}\n"}}}

--- a/docs/python/snapshots/fd940a06bbf0714ab1839fa73a9769e4.json
+++ b/docs/python/snapshots/fd940a06bbf0714ab1839fa73a9769e4.json
@@ -1,0 +1,1 @@
+{"file":"reference/table-operations/partitioned-tables/metadata-methods.md","objects":{":log":{"type":"Log","data":"deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0xfffe1001df92, num_rows = 5, columns = {'IntCol':...}))\n"}}}


### PR DESCRIPTION
## Summary
- Fix the `sanityCheckJoins` caution note to use the real parameter name in each language: `sanity_check_joins` (Python) / `sanityCheckJoinOperations` (Groovy).
- Fix a Python `[!NOTE]` that described the proxy's `target` as something to "call" — it's a plain attribute, not a method.
- Update the GIL caution box to acknowledge free-threaded Python builds, consistent with `conceptual/query-engine/parallelization.md`.
- Link `natural_join`/`where_in`/`where_not_in` (and Groovy equivalents) to their reference pages.
- Fix `constituent_tables`' documented return type in `metadata-methods.md` (`List[Table]`, not `List[str]`), and add the missing `table` and `constituent_table_definition` sections with verified, snapshot-tested examples.

Found via a `deephaven-core-accuracy-check` pass over `docs/python/how-to-guides/partitioned-tables.md` and `docs/groovy/how-to-guides/partitioned-tables.md`; every claim was verified against source (`py/server/deephaven/table.py`, `engine/api/.../PartitionedTable.java`) before fixing.

Note: this PR does **not** remove the manual execution-context capture/reopen pattern in these guides. That was the original ask, but I verified it would break the examples — `AbstractScriptSession` marks every console session's execution context as systemic, so `ExecutionContext.getContextToRecord()` (which `transform()`/`partitioned_transform()`'s convenience overloads rely on) never captures anything for code run directly in the console. Confirmed empirically by running the simplified examples against a local build through the snapshotter harness.

## Test plan
- [x] Ran `./docs/updateSnapshots` — completed with no errors; new snapshots for the two new `metadata-methods.md` examples verified to produce correct output.
- [x] Verified every changed identifier/link against source (`table.py`, `PartitionedTable.java`) and existing reference pages.
