### PR TITLE
fix: Guard Publish Check CI results against a missing artifact

### DIFF
--- a/.github/workflows/publish-check-ci.yml
+++ b/.github/workflows/publish-check-ci.yml
@@ -18,6 +18,7 @@ jobs:
       # Unfortunately, the official actions/download-artifact action is very limited in scope.
       # Can't use it yet in this context, https://github.com/actions/download-artifact/issues/60
       - name: Download artifact
+        id: download
         uses: actions/github-script@v7
         with:
           script: |
@@ -29,6 +30,14 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "check-ci-results"
             })[0];
+            if (!matchArtifact) {
+              // The "checks" job in Check CI is skipped for docs-only changes (and similar
+              // path-filtered cases), so it never uploads this artifact. That's expected, not
+              // an error, so just skip publishing instead of crashing on `matchArtifact.id`.
+              console.log('No check-ci-results artifact found for this run; the checks job was likely skipped. Nothing to publish.');
+              core.setOutput('found', 'false');
+              return;
+            }
             var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -37,8 +46,12 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/check-ci-results.zip', Buffer.from(download.data));
-      - run: unzip check-ci-results.zip
+            core.setOutput('found', 'true');
+      - name: Unzip artifact
+        if: steps.download.outputs.found == 'true'
+        run: unzip check-ci-results.zip
       - name: Publish Test Results
+        if: steps.download.outputs.found == 'true'
         uses: scacap/action-surefire-report@v1
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'


### PR DESCRIPTION
## Summary

`Publish Check CI results` (`.github/workflows/publish-check-ci.yml`) fails with an unhandled `TypeError: Cannot read properties of undefined (reading 'id')` on essentially every docs-only PR (and any other case where Check CI's `checks` job is skipped).

**Root cause:**
- `.github/workflows/check-ci.yml`'s `checks` job only runs `if: needs.changes.outputs.non-docs == 'true' || startsWith(github.ref, 'refs/heads/release/v')`. For a docs-only PR, this job — and the `check-ci-results` artifact it uploads — never runs.
- `publish-check-ci.yml` triggers unconditionally on every `workflow_run` completion of "Check CI" and assumes the artifact exists:
  ```js
  var matchArtifact = artifacts.data.artifacts.filter(a => a.name == "check-ci-results")[0];
  var download = await github.rest.actions.downloadArtifact({ ..., artifact_id: matchArtifact.id, ... });
  ```
  When the artifact is missing, `matchArtifact` is `undefined` and `matchArtifact.id` throws, failing the whole run.

Verified against real run history (`gh run list --workflow="Publish Check CI results"`): every recent failure matches this exact stack trace, including two of our own docs-only PR pushes today.

## Fix
Guard the artifact lookup: when no `check-ci-results` artifact is found, log why and set a step output instead of crashing, then skip the `unzip`/`Publish Test Results` steps via `if: steps.download.outputs.found == 'true'`.

This workflow only publishes JUnit test-report annotations from Check CI — it's informational, not a merge gate — so skipping cleanly when there's nothing to publish is the correct behavior.

## Test plan
- [x] Validated YAML structure (Ruby's YAML parser).
- [x] Syntax-checked the embedded `actions/github-script` JS with Node (`node --check`).
- [ ] Can't trigger a real `workflow_run` event locally — please verify on the next docs-only PR that this workflow now completes successfully (skipping the publish steps) instead of failing.
