### PR TITLE
test: no-ticket: Speed up slow nightly and check tests.

### DIFF
--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
@@ -39,10 +39,12 @@ import io.deephaven.engine.util.TableTools;
 import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.LongVector;
+import io.deephaven.test.types.OutOfBandTest;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -62,6 +64,7 @@ import static org.junit.Assert.*;
 /**
  * Test QueryTable select and update operations.
  */
+@Category(OutOfBandTest.class)
 public class QueryTableSelectUpdateTest {
 
     @Rule

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -360,7 +360,7 @@ public class QueryTableSliceTest extends QueryTableTestBase {
     }
 
     public void testGrowthAppendUpdatePattern() {
-        final long steps = 4096;
+        final long steps = 1024;
 
         for (int j = 1; j < 100; j += 7) {
             final QueryTable upTable = getTable(true, 0, new Random(0), new ColumnInfo[0]);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
@@ -10,7 +10,9 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter;
 import io.deephaven.engine.table.impl.select.IncrementalReleaseFilter;
+import io.deephaven.test.types.OutOfBandTest;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -23,6 +25,7 @@ import static io.deephaven.engine.util.TableTools.intCol;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.testutil.TstUtils;
 
+@Category(OutOfBandTest.class)
 public class TestIncrementalReleaseFilter extends RefreshingTableTestCase {
     public void testSimple() {
         final Table source = TableTools.newTable(TableTools.intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));


### PR DESCRIPTION
- Move QueryTableSelectUpdateTest and TestIncrementalReleaseFilter to OutOfBandTest so their incremental-fuzz and wall-clock-bound tests run nightly instead of in every check invocation.
- QueryTableSliceTest.testGrowthAppendUpdatePattern: reduce steps from 4096 to 1024; per-step whole-table validation is quadratic in steps (16 min -> ~70 s in CI). Slice boundary transitions all occur in the first ~50 rows, so the remaining steps still cover them plus a long steady-state tail.