### PR TITLE
fix: DH-23591: Use the correct keyspace for indexed natural join EXACTLY_ONE_MATCH errors

### DIFF
--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     testImplementation libs.junit4
 
     testImplementation platform(libs.junit.bom)
+    testImplementation libs.junit.jupiter
     testImplementation libs.assertj
 
     testRuntimeOnly project(':log-to-slf4j')

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticHashedNaturalJoinStateManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticHashedNaturalJoinStateManager.java
@@ -59,9 +59,14 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
             RowSet indexTableRowSet, IntegerArraySource leftHashSlots,
             ColumnSource<RowSet> indexRowSets, JoinControl.RedirectionType redirectionType);
 
+    /**
+     * @param keySourcesFromLeftTable whether {@code keySourcesForErrorMessages} are columns of the left table (as when
+     *        building from redirections) rather than columns of the data index table (as when building from hash
+     *        slots); determines which keyspace error row keys are produced in
+     */
     protected WritableRowRedirection buildIndexedRowRedirection(QueryTable leftTable,
             RowSet indexTableRowSet, LongUnaryOperator groupPositionToRightSide, ColumnSource<RowSet> leftRowSets,
-            JoinControl.RedirectionType redirectionType) {
+            JoinControl.RedirectionType redirectionType, boolean keySourcesFromLeftTable) {
         final int rowSetCount = indexTableRowSet.intSize();
         switch (redirectionType) {
             case Contiguous: {
@@ -72,7 +77,9 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
                 final long[] innerIndex = new long[leftTable.intSize("contiguous redirection build")];
                 for (int ii = 0; ii < rowSetCount; ++ii) {
                     final long rightSide = groupPositionToRightSide.applyAsLong(ii);
-                    checkExactMatch(ii, rightSide);
+                    if (rightSide == NO_RIGHT_ENTRY_VALUE) {
+                        checkExactMatchForGroup(keySourcesFromLeftTable, indexTableRowSet, leftRowSets, ii);
+                    }
                     final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
                     leftRowSetForKey.forAllRowKeys((long ll) -> innerIndex[(int) ll] = rightSide);
                 }
@@ -84,8 +91,9 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
                 for (int ii = 0; ii < rowSetCount; ++ii) {
                     final long rightSide = groupPositionToRightSide.applyAsLong(ii);
 
-                    checkExactMatch(ii, rightSide);
-                    if (rightSide != NO_RIGHT_ENTRY_VALUE) {
+                    if (rightSide == NO_RIGHT_ENTRY_VALUE) {
+                        checkExactMatchForGroup(keySourcesFromLeftTable, indexTableRowSet, leftRowSets, ii);
+                    } else {
                         final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
                         leftRowSetForKey.forAllRowKeys((long ll) -> sparseRedirections.set(ll, rightSide));
                     }
@@ -99,8 +107,9 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
                 for (int ii = 0; ii < rowSetCount; ++ii) {
                     final long rightSide = groupPositionToRightSide.applyAsLong(ii);
 
-                    checkExactMatch(ii, rightSide);
-                    if (rightSide != NO_RIGHT_ENTRY_VALUE) {
+                    if (rightSide == NO_RIGHT_ENTRY_VALUE) {
+                        checkExactMatchForGroup(keySourcesFromLeftTable, indexTableRowSet, leftRowSets, ii);
+                    } else {
                         final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
                         leftRowSetForKey.forAllRowKeys((long ll) -> rowRedirection.put(ll, rightSide));
                     }
@@ -110,6 +119,22 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
             }
         }
         throw new IllegalStateException("Bad redirectionType: " + redirectionType);
+    }
+
+    /**
+     * Check for an {@link NaturalJoinType#EXACTLY_ONE_MATCH} violation for the group at {@code groupPosition}, which
+     * has no right-side match. The failing key is rendered from {@code keySourcesForErrorMessages}, which are columns
+     * of the left table or of the data index table depending on how this state manager was constructed, so the group
+     * must be mapped to a row key in the matching keyspace.
+     */
+    private void checkExactMatchForGroup(final boolean keySourcesFromLeftTable, final RowSet indexTableRowSet,
+            final ColumnSource<RowSet> leftRowSets, final long groupPosition) {
+        if (joinType != NaturalJoinType.EXACTLY_ONE_MATCH) {
+            return;
+        }
+        final long indexRowKey = indexTableRowSet.get(groupPosition);
+        final long errorRowKey = keySourcesFromLeftTable ? leftRowSets.get(indexRowKey).firstRowKey() : indexRowKey;
+        checkExactMatch(errorRowKey, NO_RIGHT_ENTRY_VALUE);
     }
 
     public void errorOnDuplicates(IntegerArraySource leftHashSlots, long size,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticNaturalJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticNaturalJoinStateManagerTypedBase.java
@@ -255,7 +255,7 @@ public abstract class StaticNaturalJoinStateManagerTypedBase extends StaticHashe
             ColumnSource<RowSet> indexRowSets,
             JoinControl.RedirectionType redirectionType) {
         return buildIndexedRowRedirection(leftTable, indexTableRowSet,
-                leftRedirections::getUnsafe, indexRowSets, redirectionType);
+                leftRedirections::getUnsafe, indexRowSets, redirectionType, true);
     }
 
     public WritableRowRedirection buildIndexedRowRedirectionFromHashSlots(
@@ -266,7 +266,7 @@ public abstract class StaticNaturalJoinStateManagerTypedBase extends StaticHashe
             JoinControl.RedirectionType redirectionType) {
         return buildIndexedRowRedirection(leftTable, indexTableRowSet,
                 (long groupPosition) -> mainRightRowKey.getUnsafe(leftHashSlots.getUnsafe(groupPosition)), indexRowSets,
-                redirectionType);
+                redirectionType, false);
     }
 
     public void errorOnDuplicatesIndexed(IntegerArraySource leftHashSlots, long size,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
@@ -52,6 +52,7 @@ import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.util.TableTools.*;
 import static io.deephaven.util.QueryConstants.NULL_INT;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 @Category(OutOfBandTest.class)
 public class QueryTableNaturalJoinTest extends QueryTableTestBase {
@@ -1614,7 +1615,8 @@ public class QueryTableNaturalJoinTest extends QueryTableTestBase {
         assertTableEquals(pairMatch, njTable);
     }
 
-    public void testExactJoinIndexedErrorMessage() {
+    public void testExactJoinIndexedErrorMessageBuildRight() {
+        // a refreshing left table forces the build from the right side
         // sparse left row keys, so no index-table group position is a valid left row key
         final QueryTable leftTable = testRefreshingTable(i(10, 20, 30).toTracking(),
                 col("String", "c", "e", "g"));
@@ -1622,12 +1624,23 @@ public class QueryTableNaturalJoinTest extends QueryTableTestBase {
 
         final Table rightTable = testTable(col("String", "c", "e"), col("v", 1, 2));
 
-        try {
-            leftTable.exactJoin(rightTable, "String");
-            TestCase.fail("Previous statement should have thrown an exception");
-        } catch (Exception e) {
-            assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
-        }
+        final RuntimeException e = assertThrowsExactly(RuntimeException.class,
+                () -> leftTable.exactJoin(rightTable, "String"));
+        assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
+    }
+
+    public void testExactJoinIndexedErrorMessageBuildLeft() {
+        // a static left table with a data index smaller than the right table builds from the left data index
+        // sparse left row keys, so no index-table group position is a valid left row key
+        final QueryTable leftTable = testTable(i(10, 20, 30).toTracking(),
+                col("String", "c", "e", "g"));
+        DataIndexer.getOrCreateDataIndex(leftTable, "String");
+
+        final Table rightTable = testTable(col("String", "c", "e", "q", "r"), col("v", 1, 2, 3, 4));
+
+        final RuntimeException e = assertThrowsExactly(RuntimeException.class,
+                () -> leftTable.exactJoin(rightTable, "String"));
+        assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
     }
 
     private ColumnInfo[] createTestColumnInfos(final float nullFraction, final int maxValue) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
@@ -1624,6 +1624,9 @@ public class QueryTableNaturalJoinTest extends QueryTableTestBase {
 
         final Table rightTable = testTable(col("String", "c", "e"), col("v", 1, 2));
 
+        // a plain natural join tolerates the unmatched key
+        assertEquals(3, leftTable.naturalJoin(rightTable, "String").size());
+
         final RuntimeException e = assertThrowsExactly(RuntimeException.class,
                 () -> leftTable.exactJoin(rightTable, "String"));
         assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
@@ -1637,6 +1640,32 @@ public class QueryTableNaturalJoinTest extends QueryTableTestBase {
         DataIndexer.getOrCreateDataIndex(leftTable, "String");
 
         final Table rightTable = testTable(col("String", "c", "e", "q", "r"), col("v", 1, 2, 3, 4));
+
+        final RuntimeException e = assertThrowsExactly(RuntimeException.class,
+                () -> leftTable.exactJoin(rightTable, "String"));
+        assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
+    }
+
+    public void testExactJoinIndexedErrorMessageContiguous() {
+        // a flat static left table produces a contiguous row redirection
+        final Table leftTable = testTable(col("String", "c", "e", "g")).flatten();
+        DataIndexer.getOrCreateDataIndex(leftTable, "String");
+
+        final Table rightTable = testTable(col("String", "c", "e", "q", "r"), col("v", 1, 2, 3, 4));
+
+        final RuntimeException e = assertThrowsExactly(RuntimeException.class,
+                () -> leftTable.exactJoin(rightTable, "String"));
+        assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
+    }
+
+    public void testExactJoinIndexedErrorMessageHash() {
+        // left row keys spread across distant blocks make a sparse redirection too wasteful, producing a hashed one
+        final QueryTable leftTable = testRefreshingTable(
+                i(10, 1L << 20, 2L << 20, 3L << 20, 4L << 20).toTracking(),
+                col("String", "c", "e", "g", "h", "j"));
+        DataIndexer.getOrCreateDataIndex(leftTable, "String");
+
+        final Table rightTable = testTable(col("String", "c", "e", "h", "j"), col("v", 1, 2, 3, 4));
 
         final RuntimeException e = assertThrowsExactly(RuntimeException.class,
                 () -> leftTable.exactJoin(rightTable, "String"));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableNaturalJoinTest.java
@@ -1614,6 +1614,22 @@ public class QueryTableNaturalJoinTest extends QueryTableTestBase {
         assertTableEquals(pairMatch, njTable);
     }
 
+    public void testExactJoinIndexedErrorMessage() {
+        // sparse left row keys, so no index-table group position is a valid left row key
+        final QueryTable leftTable = testRefreshingTable(i(10, 20, 30).toTracking(),
+                col("String", "c", "e", "g"));
+        DataIndexer.getOrCreateDataIndex(leftTable, "String");
+
+        final Table rightTable = testTable(col("String", "c", "e"), col("v", 1, 2));
+
+        try {
+            leftTable.exactJoin(rightTable, "String");
+            TestCase.fail("Previous statement should have thrown an exception");
+        } catch (Exception e) {
+            assertEquals("Tables don't have one-to-one mapping - no mappings for key g.", e.getMessage());
+        }
+    }
+
     private ColumnInfo[] createTestColumnInfos(final float nullFraction, final int maxValue) {
         final List<String> colsList = new ArrayList<>();
         final List<TestDataGenerator> generators = new ArrayList<>();


### PR DESCRIPTION
buildIndexedRowRedirection passed the index table group position to checkExactMatch, which expects a row key in the keyspace of keySourcesForErrorMessages: left-table columns when building from redirections, data-index-table columns when building from hash slots. Resolve the failing group to a row key in the matching keyspace, computed only on the failure path.

Before this change, a failing EXACTLY_ONE_MATCH indexed join with non-flat left row keys reported "Asking for a non-existent key" from the error-message rendering instead of the join diagnostic; adds a regression test covering that case.