### PR TITLE
perf: DH-23593: Use bulk RowSet operations instead of per-element get/find in loops

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/iterators/SerialColumnIterator.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/iterators/SerialColumnIterator.java
@@ -20,11 +20,14 @@ import java.util.function.BiFunction;
 public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<DATA_TYPE> {
 
     final ColumnSource<DATA_TYPE> columnSource;
-    private final RowSet rowSet;
 
+    private final RowSet.SearchIterator keyIterator;
     private final long lastRowPositionExclusive;
 
     private long nextRowPosition;
+    // Whether keyIterator has been advanced to the first row key, which must then be consumed via currentValue()
+    // rather than nextLong()
+    private boolean pendingAdvancedKey;
 
     /**
      * Create a new SerialColumnIterator.
@@ -40,7 +43,6 @@ public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<
             final long firstRowKey,
             final long length) {
         this.columnSource = columnSource;
-        this.rowSet = rowSet;
         if (firstRowKey == rowSet.firstRowKey()) {
             nextRowPosition = 0;
         } else if ((nextRowPosition = rowSet.find(firstRowKey)) < 0) {
@@ -53,6 +55,15 @@ public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<
                     length, rowSet.size(), nextRowPosition));
         }
         lastRowPositionExclusive = nextRowPosition + length;
+        if (length == 0) {
+            keyIterator = null;
+        } else {
+            keyIterator = rowSet.searchIterator();
+            if (nextRowPosition != 0) {
+                keyIterator.advance(firstRowKey);
+                pendingAdvancedKey = true;
+            }
+        }
     }
 
     @Override
@@ -74,7 +85,19 @@ public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<
         if (nextRowPosition == lastRowPositionExclusive) {
             throw new NoSuchElementException();
         }
-        return rowSet.get(nextRowPosition++);
+        ++nextRowPosition;
+        if (pendingAdvancedKey) {
+            pendingAdvancedKey = false;
+            return keyIterator.currentValue();
+        }
+        return keyIterator.nextLong();
+    }
+
+    @Override
+    public final void close() {
+        if (keyIterator != null) {
+            keyIterator.close();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/api/src/main/java/io/deephaven/engine/table/iterators/SerialColumnIterator.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/iterators/SerialColumnIterator.java
@@ -21,7 +21,8 @@ public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<
 
     final ColumnSource<DATA_TYPE> columnSource;
 
-    private final RowSet.SearchIterator keyIterator;
+    // Released when the final requested key is consumed, or on close
+    private RowSet.SearchIterator keyIterator;
     private final long lastRowPositionExclusive;
 
     private long nextRowPosition;
@@ -86,17 +87,24 @@ public abstract class SerialColumnIterator<DATA_TYPE> implements ColumnIterator<
             throw new NoSuchElementException();
         }
         ++nextRowPosition;
+        final long result;
         if (pendingAdvancedKey) {
             pendingAdvancedKey = false;
-            return keyIterator.currentValue();
+            result = keyIterator.currentValue();
+        } else {
+            result = keyIterator.nextLong();
         }
-        return keyIterator.nextLong();
+        if (nextRowPosition == lastRowPositionExclusive) {
+            close();
+        }
+        return result;
     }
 
     @Override
     public final void close() {
         if (keyIterator != null) {
             keyIterator.close();
+            keyIterator = null;
         }
     }
 

--- a/engine/api/src/test/java/io/deephaven/engine/table/iterators/TestColumnIterators.java
+++ b/engine/api/src/test/java/io/deephaven/engine/table/iterators/TestColumnIterators.java
@@ -18,6 +18,7 @@ import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.util.mutable.MutableInt;
 import org.junit.*;
 
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Random;
 import java.util.function.Consumer;
@@ -33,7 +34,9 @@ import static io.deephaven.util.QueryConstants.NULL_LONG;
 import static io.deephaven.util.QueryConstants.NULL_SHORT;
 import static io.deephaven.util.type.TypeUtils.box;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 
 /**
  * Unit tests for {@link ColumnIterator} implementations.
@@ -762,6 +765,59 @@ public class TestColumnIterators {
                     .filter((final String value) -> !(Objects.equals(value,
                             data.get(nextValueIndex.getAndIncrement()))))
                     .count());
+        }
+    }
+
+    @Test
+    public void testSerialColumnIteratorPartialRange() {
+        final ColumnSource<Long> source = input.getColumnSource("LongCol", long.class);
+        final RowSet rows = input.getRowSet();
+
+        // Start mid-row-set, so construction must advance the key iterator to the first requested key, and stop short
+        // of the end, so exhaustion releases the key iterator before the backing row set is consumed
+        final long startPosition = rows.size() / 3;
+        final long startKey = rows.get(startPosition);
+        final long length = Math.min(1000, rows.size() - startPosition - 1);
+        try (final LongColumnIterator serial = new SerialLongColumnIterator(source, rows, startKey, length)) {
+            for (long li = 0; li < length; ++li) {
+                assertEquals(length - li, serial.remaining());
+                assertTrue(serial.hasNext());
+                assertEquals(source.getLong(rows.get(startPosition + li)), serial.nextLong());
+            }
+            assertEquals(0, serial.remaining());
+            assertFalse(serial.hasNext());
+            try {
+                serial.nextLong();
+                fail("expected NoSuchElementException");
+            } catch (NoSuchElementException expected) {
+            }
+        }
+
+        // Abandoning a partially-consumed iterator releases via close
+        try (final LongColumnIterator serial = new SerialLongColumnIterator(source, rows, startKey, length)) {
+            assertEquals(source.getLong(startKey), serial.nextLong());
+        }
+
+        // An empty range never creates a key iterator
+        try (final LongColumnIterator serial = new SerialLongColumnIterator(source, rows, startKey, 0)) {
+            assertFalse(serial.hasNext());
+            assertEquals(0, serial.remaining());
+        }
+
+        // The first row key must be present in the row set
+        try {
+            // noinspection resource
+            new SerialLongColumnIterator(source, rows, rows.lastRowKey() + 1, 1);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        // The length must not exceed the rows remaining from the first row key
+        try {
+            // noinspection resource
+            new SerialLongColumnIterator(source, rows, startKey, rows.size());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
         }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ConstituentDependency.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ConstituentDependency.java
@@ -70,6 +70,9 @@ public class ConstituentDependency implements Dependency {
 
     private long lastQueriedStep = NotificationStepReceiver.NULL_NOTIFICATION_STEP;
     private long firstUnsatisfiedRowPosition = 0;
+    // The row key at firstUnsatisfiedRowPosition when it is nonzero. The result row set cannot change between polls on
+    // the same step, because we only examine it after the result-updated dependency is satisfied.
+    private long firstUnsatisfiedRowKey = RowSequence.NULL_ROW_KEY;
 
     private ConstituentDependency(
             @NotNull final Dependency resultUpdatedDependency,
@@ -118,6 +121,7 @@ public class ConstituentDependency implements Dependency {
                 // Re-initialize for this cycle
                 lastQueriedStep = step;
                 firstUnsatisfiedRowPosition = 0;
+                firstUnsatisfiedRowKey = RowSequence.NULL_ROW_KEY;
             }
             final int chunkSize = Math.toIntExact(Math.min(DEFAULT_CHUNK_SIZE, resultRows.size()));
             final int numColumns = dependencyColumns.length;
@@ -126,7 +130,7 @@ public class ConstituentDependency implements Dependency {
                     final SafeCloseable ignored = new SafeCloseableArray<>(contexts);
                     final RowSequence.Iterator rows = resultRows.getRowSequenceIterator()) {
                 if (firstUnsatisfiedRowPosition > 0) {
-                    rows.advance(resultRows.get(firstUnsatisfiedRowPosition));
+                    rows.advance(firstUnsatisfiedRowKey);
                 }
                 for (int ci = 0; ci < numColumns; ++ci) {
                     contexts[ci] = dependencyColumns[ci].makeGetContext(chunkSize, sharedContext);
@@ -145,6 +149,7 @@ public class ConstituentDependency implements Dependency {
                                         .append(this).append(", constituent=").append(constituent)
                                         .endl();
                                 firstUnsatisfiedRowPosition += di;
+                                firstUnsatisfiedRowKey = sliceRows.asRowKeyChunk().get(di);
                                 return false;
                             }
                         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/StaticNaturalJoinStateManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/StaticNaturalJoinStateManager.java
@@ -61,7 +61,8 @@ public abstract class StaticNaturalJoinStateManager {
                 final long[] innerIndex = new long[leftTable.intSize("contiguous redirection build")];
                 for (int ii = 0; ii < innerIndex.length; ++ii) {
                     final long rightSide = rightSideFromSlot.applyAsLong(ii);
-                    checkExactMatch(leftTable.getRowSet().get(ii), rightSide);
+                    // the table is flat, so the row position is also the row key
+                    checkExactMatch(ii, rightSide);
                     innerIndex[ii] = rightSide;
                 }
                 return new ContiguousWritableRowRedirection(innerIndex);
@@ -73,7 +74,7 @@ public abstract class StaticNaturalJoinStateManager {
                 for (final RowSet.Iterator it = leftTable.getRowSet().iterator(); it.hasNext();) {
                     final long next = it.nextLong();
                     final long rightSide = rightSideFromSlot.applyAsLong(leftPosition++);
-                    checkExactMatch(leftTable.getRowSet().get(next), rightSide);
+                    checkExactMatch(next, rightSide);
                     if (rightSide != NO_RIGHT_ENTRY_VALUE) {
                         sparseRedirections.set(next, rightSide);
                     }
@@ -88,7 +89,7 @@ public abstract class StaticNaturalJoinStateManager {
                 for (final RowSet.Iterator it = leftTable.getRowSet().iterator(); it.hasNext();) {
                     final long next = it.nextLong();
                     final long rightSide = rightSideFromSlot.applyAsLong(leftPosition++);
-                    checkExactMatch(leftTable.getRowSet().get(next), rightSide);
+                    checkExactMatch(next, rightSide);
                     if (rightSide != NO_RIGHT_ENTRY_VALUE) {
                         rowRedirection.put(next, rightSide);
                     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticHashedNaturalJoinStateManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/StaticHashedNaturalJoinStateManager.java
@@ -70,24 +70,30 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
                 }
                 // we can use an array, which is perfect for a small enough flat table
                 final long[] innerIndex = new long[leftTable.intSize("contiguous redirection build")];
-                for (int ii = 0; ii < rowSetCount; ++ii) {
-                    final long rightSide = groupPositionToRightSide.applyAsLong(ii);
-                    checkExactMatch(ii, rightSide);
-                    final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
-                    leftRowSetForKey.forAllRowKeys((long ll) -> innerIndex[(int) ll] = rightSide);
+                try (final RowSet.Iterator indexKeyIt = indexTableRowSet.iterator()) {
+                    for (int ii = 0; ii < rowSetCount; ++ii) {
+                        final long indexRowKey = indexKeyIt.nextLong();
+                        final long rightSide = groupPositionToRightSide.applyAsLong(ii);
+                        checkExactMatch(indexRowKey, rightSide);
+                        final RowSet leftRowSetForKey = leftRowSets.get(indexRowKey);
+                        leftRowSetForKey.forAllRowKeys((long ll) -> innerIndex[(int) ll] = rightSide);
+                    }
                 }
                 return new ContiguousWritableRowRedirection(innerIndex);
             }
             case Sparse: {
                 final LongSparseArraySource sparseRedirections = new LongSparseArraySource();
 
-                for (int ii = 0; ii < rowSetCount; ++ii) {
-                    final long rightSide = groupPositionToRightSide.applyAsLong(ii);
+                try (final RowSet.Iterator indexKeyIt = indexTableRowSet.iterator()) {
+                    for (int ii = 0; ii < rowSetCount; ++ii) {
+                        final long indexRowKey = indexKeyIt.nextLong();
+                        final long rightSide = groupPositionToRightSide.applyAsLong(ii);
 
-                    checkExactMatch(ii, rightSide);
-                    if (rightSide != NO_RIGHT_ENTRY_VALUE) {
-                        final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
-                        leftRowSetForKey.forAllRowKeys((long ll) -> sparseRedirections.set(ll, rightSide));
+                        checkExactMatch(indexRowKey, rightSide);
+                        if (rightSide != NO_RIGHT_ENTRY_VALUE) {
+                            final RowSet leftRowSetForKey = leftRowSets.get(indexRowKey);
+                            leftRowSetForKey.forAllRowKeys((long ll) -> sparseRedirections.set(ll, rightSide));
+                        }
                     }
                 }
                 return new LongColumnSourceWritableRowRedirection(sparseRedirections);
@@ -96,13 +102,16 @@ public abstract class StaticHashedNaturalJoinStateManager extends StaticNaturalJ
                 final WritableRowRedirection rowRedirection =
                         WritableRowRedirectionLockFree.FACTORY.createRowRedirection(leftTable.intSize());
 
-                for (int ii = 0; ii < rowSetCount; ++ii) {
-                    final long rightSide = groupPositionToRightSide.applyAsLong(ii);
+                try (final RowSet.Iterator indexKeyIt = indexTableRowSet.iterator()) {
+                    for (int ii = 0; ii < rowSetCount; ++ii) {
+                        final long indexRowKey = indexKeyIt.nextLong();
+                        final long rightSide = groupPositionToRightSide.applyAsLong(ii);
 
-                    checkExactMatch(ii, rightSide);
-                    if (rightSide != NO_RIGHT_ENTRY_VALUE) {
-                        final RowSet leftRowSetForKey = leftRowSets.get(indexTableRowSet.get(ii));
-                        leftRowSetForKey.forAllRowKeys((long ll) -> rowRedirection.put(ll, rightSide));
+                        checkExactMatch(indexRowKey, rightSide);
+                        if (rightSide != NO_RIGHT_ENTRY_VALUE) {
+                            final RowSet leftRowSetForKey = leftRowSets.get(indexRowKey);
+                            leftRowSetForKey.forAllRowKeys((long ll) -> rowRedirection.put(ll, rightSide));
+                        }
                     }
                 }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/replay/ReplayLastByGroupedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/replay/ReplayLastByGroupedTable.java
@@ -6,7 +6,6 @@ package io.deephaven.engine.table.impl.replay;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetBuilderRandom;
 import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.util.*;
 import io.deephaven.time.DateTimeUtils;
@@ -26,13 +25,18 @@ public class ReplayLastByGroupedTable extends QueryReplayGroupedTable {
         if (allIterators.isEmpty()) {
             return;
         }
-        RowSetBuilderRandom candidatesBuilder = RowSetFactory.builderRandom();
+        RowSetBuilderRandom addedBuilder = RowSetFactory.builderRandom();
+        RowSetBuilderRandom modifiedBuilder = RowSetFactory.builderRandom();
         // List<IteratorsAndNextTime> iteratorsToAddBack = new ArrayList<>(allIterators.size());
         while (!allIterators.isEmpty()
                 && DateTimeUtils.epochNanos(allIterators.peek().lastTime) < replayer.clock().currentTimeNanos()) {
             IteratorsAndNextTime currentIt = allIterators.poll();
             rowRedirection.put(currentIt.pos, currentIt.lastIndex);
-            candidatesBuilder.addKey(currentIt.pos);
+            if (getRowSet().find(currentIt.pos) >= 0) {
+                modifiedBuilder.addKey(currentIt.pos);
+            } else {
+                addedBuilder.addKey(currentIt.pos);
+            }
             do {
                 currentIt = currentIt.next();
             } while (currentIt != null
@@ -41,9 +45,8 @@ public class ReplayLastByGroupedTable extends QueryReplayGroupedTable {
                 allIterators.add(currentIt);
             }
         }
-        // rows already in the result are modifies; the remainder are adds
-        final WritableRowSet added = candidatesBuilder.build();
-        final RowSet modified = added.extract(getRowSet());
+        final RowSet added = addedBuilder.build();
+        final RowSet modified = modifiedBuilder.build();
         if (!added.isEmpty() || !modified.isEmpty()) {
             getRowSet().writableCast().insert(added);
             notifyListeners(added, RowSetFactory.empty(), modified);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/replay/ReplayLastByGroupedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/replay/ReplayLastByGroupedTable.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.replay;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetBuilderRandom;
 import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.util.*;
 import io.deephaven.time.DateTimeUtils;
@@ -25,18 +26,13 @@ public class ReplayLastByGroupedTable extends QueryReplayGroupedTable {
         if (allIterators.isEmpty()) {
             return;
         }
-        RowSetBuilderRandom addedBuilder = RowSetFactory.builderRandom();
-        RowSetBuilderRandom modifiedBuilder = RowSetFactory.builderRandom();
+        RowSetBuilderRandom candidatesBuilder = RowSetFactory.builderRandom();
         // List<IteratorsAndNextTime> iteratorsToAddBack = new ArrayList<>(allIterators.size());
         while (!allIterators.isEmpty()
                 && DateTimeUtils.epochNanos(allIterators.peek().lastTime) < replayer.clock().currentTimeNanos()) {
             IteratorsAndNextTime currentIt = allIterators.poll();
             rowRedirection.put(currentIt.pos, currentIt.lastIndex);
-            if (getRowSet().find(currentIt.pos) >= 0) {
-                modifiedBuilder.addKey(currentIt.pos);
-            } else {
-                addedBuilder.addKey(currentIt.pos);
-            }
+            candidatesBuilder.addKey(currentIt.pos);
             do {
                 currentIt = currentIt.next();
             } while (currentIt != null
@@ -45,8 +41,9 @@ public class ReplayLastByGroupedTable extends QueryReplayGroupedTable {
                 allIterators.add(currentIt);
             }
         }
-        final RowSet added = addedBuilder.build();
-        final RowSet modified = modifiedBuilder.build();
+        // rows already in the result are modifies; the remainder are adds
+        final WritableRowSet added = candidatesBuilder.build();
+        final RowSet modified = added.extract(getRowSet());
         if (!added.isEmpty() || !modified.isEmpty()) {
             getRowSet().writableCast().insert(added);
             notifyListeners(added, RowSetFactory.empty(), modified);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateSlicedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateSlicedColumnSource.java
@@ -10,6 +10,7 @@ import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.SharedContext;
@@ -230,11 +231,16 @@ public abstract class BaseAggregateSlicedColumnSource<VECTOR_TYPE extends Vector
                 continue;
             }
             final RowSet groupRowSetPrev = rowSetChunk.get(ii);
-            final RowSet bucketRowSet = groupRowSetPrev.isTracking()
-                    ? groupRowSetPrev.trackingCast().prev()
-                    : groupRowSetPrev;
-            final long rowPos = bucketRowSet.find(keyChunk.get(ii));
-            final long bucketSize = bucketRowSet.size();
+            final long rowPos;
+            final long bucketSize;
+            if (groupRowSetPrev.isTracking()) {
+                final TrackingRowSet trackingGroupRowSet = groupRowSetPrev.trackingCast();
+                rowPos = trackingGroupRowSet.findPrev(keyChunk.get(ii));
+                bucketSize = trackingGroupRowSet.sizePrev();
+            } else {
+                rowPos = groupRowSetPrev.find(keyChunk.get(ii));
+                bucketSize = groupRowSetPrev.size();
+            }
             final long startPos = ClampUtil.clampLong(0, bucketSize, rowPos + localStartOffset);
             final long endPos = ClampUtil.clampLong(0, bucketSize, rowPos + localEndOffset);
             sizes.set(ii, endPos - startPos);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateSlicedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateSlicedColumnSource.java
@@ -4,8 +4,13 @@
 package io.deephaven.engine.table.impl.sources.aggregate;
 
 import io.deephaven.base.ClampUtil;
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.SharedContext;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
@@ -170,6 +175,71 @@ public abstract class BaseAggregateSlicedColumnSource<VECTOR_TYPE extends Vector
         final long endPos = ClampUtil.clampLong(0, size, rowPos + endOffset);
 
         return endPos - startPos;
+    }
+
+    @Override
+    public void getUngroupedSize(final FillContext fillContext, final RowSequence rowSequence,
+            final WritableLongChunk<Values> sizes) {
+        final AggregateSlicedFillContext ctx = (AggregateSlicedFillContext) fillContext;
+        final ObjectChunk<RowSet, ? extends Values> rowSetChunk =
+                groupRowSetSource.getChunk(ctx.groupRowSetGetContext, rowSequence).asObjectChunk();
+        final LongChunk<? extends Values> startChunk = startSource != null
+                ? startSource.getChunk(ctx.startGetContext, rowSequence).asLongChunk()
+                : null;
+        final LongChunk<? extends Values> endChunk = endSource != null
+                ? endSource.getChunk(ctx.endGetContext, rowSequence).asLongChunk()
+                : null;
+        final LongChunk<OrderedRowKeys> keyChunk = rowSequence.asRowKeyChunk();
+        final int size = keyChunk.size();
+        for (int ii = 0; ii < size; ++ii) {
+            final long localStartOffset = startChunk != null ? startChunk.get(ii) : startOffset;
+            final long localEndOffset = endChunk != null ? endChunk.get(ii) : endOffset;
+            if (localStartOffset == NULL_LONG || localEndOffset == NULL_LONG) {
+                sizes.set(ii, 0);
+                continue;
+            }
+            final RowSet bucketRowSet = rowSetChunk.get(ii);
+            final long rowPos = bucketRowSet.find(keyChunk.get(ii));
+            final long bucketSize = bucketRowSet.size();
+            final long startPos = ClampUtil.clampLong(0, bucketSize, rowPos + localStartOffset);
+            final long endPos = ClampUtil.clampLong(0, bucketSize, rowPos + localEndOffset);
+            sizes.set(ii, endPos - startPos);
+        }
+        sizes.setSize(size);
+    }
+
+    @Override
+    public void getUngroupedPrevSize(final FillContext fillContext, final RowSequence rowSequence,
+            final WritableLongChunk<Values> sizes) {
+        final AggregateSlicedFillContext ctx = (AggregateSlicedFillContext) fillContext;
+        final ObjectChunk<RowSet, ? extends Values> rowSetChunk =
+                groupRowSetSource.getPrevChunk(ctx.groupRowSetGetContext, rowSequence).asObjectChunk();
+        final LongChunk<? extends Values> startChunk = startSource != null
+                ? startSource.getPrevChunk(ctx.startGetContext, rowSequence).asLongChunk()
+                : null;
+        final LongChunk<? extends Values> endChunk = endSource != null
+                ? endSource.getPrevChunk(ctx.endGetContext, rowSequence).asLongChunk()
+                : null;
+        final LongChunk<OrderedRowKeys> keyChunk = rowSequence.asRowKeyChunk();
+        final int size = keyChunk.size();
+        for (int ii = 0; ii < size; ++ii) {
+            final long localStartOffset = startChunk != null ? startChunk.get(ii) : startOffset;
+            final long localEndOffset = endChunk != null ? endChunk.get(ii) : endOffset;
+            if (localStartOffset == NULL_LONG || localEndOffset == NULL_LONG) {
+                sizes.set(ii, 0);
+                continue;
+            }
+            final RowSet groupRowSetPrev = rowSetChunk.get(ii);
+            final RowSet bucketRowSet = groupRowSetPrev.isTracking()
+                    ? groupRowSetPrev.trackingCast().prev()
+                    : groupRowSetPrev;
+            final long rowPos = bucketRowSet.find(keyChunk.get(ii));
+            final long bucketSize = bucketRowSet.size();
+            final long startPos = ClampUtil.clampLong(0, bucketSize, rowPos + localStartOffset);
+            final long endPos = ClampUtil.clampLong(0, bucketSize, rowPos + localEndOffset);
+            sizes.set(ii, endPos - startPos);
+        }
+        sizes.setSize(size);
     }
 
     protected RowSet getPrevGroupRowSet(final long groupIndexKey) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/UngroupedAggregateSlicedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/UngroupedAggregateSlicedColumnSource.java
@@ -8,10 +8,14 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.LongChunkAppender;
+import io.deephaven.chunk.util.LongChunkIterator;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSequenceFactory;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.SharedContext;
 import io.deephaven.engine.table.impl.sources.UngroupedColumnSource;
@@ -216,8 +220,6 @@ final class UngroupedAggregateSlicedColumnSource<DATA_TYPE>
 
                     // Read the total length of items in this group
                     final int lengthFromThisGroup = sameGroupRunLengths.get(ii);
-                    // Determine when to stop iterating for the items in this group
-                    final long endIndex = currentIndex + lengthFromThisGroup;
 
                     // Get the row key and determine the starting position for the first entry of this group
                     final long rowKey = groupRowKeys.get(ii);
@@ -225,17 +227,19 @@ final class UngroupedAggregateSlicedColumnSource<DATA_TYPE>
                     final long localStartOffset = startOffsets != null ? startOffsets.get(ii) : startOffset;
                     final long startPos = ClampUtil.clampLong(0, bucketSize, rowPos + localStartOffset);
 
-                    while (currentIndex < endIndex) {
-                        // Read the offset for this output row and determine the key in the underlying source
-                        final long offsetInGroup = componentRowKeys.get(currentIndex);
-                        final long pos = startPos + offsetInGroup;
-                        final long key = bucketRowSet.get(pos);
+                    final WritableLongChunk<OrderedRowKeys> remappedComponentKeys = componentRowKeySlice
+                            .resetFromTypedChunk(componentRowKeys, currentIndex, lengthFromThisGroup);
 
-                        // Map component row position to row key in-place
-                        componentRowKeys.set(currentIndex, key);
-
-                        currentIndex++;
+                    // Offset the component row positions by the group's start position
+                    for (int ci = 0; ci < lengthFromThisGroup; ++ci) {
+                        remappedComponentKeys.set(ci, remappedComponentKeys.get(ci) + startPos);
                     }
+                    // Invert the component row positions to component row keys, in-place
+                    bucketRowSet.getKeysForPositions(
+                            new LongChunkIterator(remappedComponentKeys),
+                            new LongChunkAppender(remappedComponentKeys));
+
+                    currentIndex += lengthFromThisGroup;
                 }
 
                 stateReusable = shared;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestConcurrentInstantiation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestConcurrentInstantiation.java
@@ -17,6 +17,8 @@ import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.hierarchical.TreeTable;
 import io.deephaven.api.filter.Filter;
+import io.deephaven.api.updateby.UpdateByOperation;
+import io.deephaven.time.DateTimeUtils;
 import io.deephaven.engine.table.impl.hierarchical.TreeTableFilter;
 import io.deephaven.engine.table.impl.hierarchical.TreeTableImpl;
 import io.deephaven.engine.table.impl.indexer.DataIndexer;
@@ -46,6 +48,8 @@ import org.junit.experimental.categories.Category;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -185,6 +189,88 @@ public class TestConcurrentInstantiation extends QueryTableTestBase {
         TstUtils.assertTableEquals(table, flat);
         TstUtils.assertTableEquals(table, flat2);
         TstUtils.assertTableEquals(table, flat3);
+    }
+
+    public void testUngroupRollingGroup() throws ExecutionException, InterruptedException, TimeoutException {
+        final QueryTable table = TstUtils.testRefreshingTable(i(2, 4, 6).toTracking(),
+                col("Sym", "a", "b", "a"), intCol("x", 1, 2, 3));
+        final Table grouped = table.updateBy(UpdateByOperation.RollingGroup(2, 0, "x"), "Sym");
+
+        final Table expect1 = TstUtils.testTable(col("Sym", "a", "b", "a"), intCol("x", 1, 2, 3))
+                .updateBy(UpdateByOperation.RollingGroup(2, 0, "x"), "Sym").ungroup("x");
+        final Table expect2 = TstUtils.testTable(col("Sym", "a", "b", "b", "a", "b"), intCol("x", 1, 4, 2, 3, 5))
+                .updateBy(UpdateByOperation.RollingGroup(2, 0, "x"), "Sym").ungroup("x");
+
+        final Callable<Table> callable = () -> grouped.ungroup("x");
+
+        updateGraph.startCycleForUnitTests(false);
+
+        final Table ungroup1 = pool.submit(callable).get(TIMEOUT_LENGTH, TIMEOUT_UNIT);
+        assertTableEquals(expect1, ungroup1);
+
+        TstUtils.addToTable(table, i(3, 8), col("Sym", "b", "b"), intCol("x", 4, 5));
+        table.notifyListeners(i(3, 8), i(), i());
+        updateGraph.markSourcesRefreshedForUnitTests();
+
+        // the rolling group has not yet processed the update, so instantiation must use previous values
+        final Table ungroup2 = pool.submit(callable).get(TIMEOUT_LENGTH, TIMEOUT_UNIT);
+
+        assertTableEquals(expect1, prevTable(ungroup1));
+        assertTableEquals(expect1, prevTable(ungroup2));
+
+        updateGraph.completeCycleForUnitTests();
+
+        assertTableEquals(expect2, ungroup1);
+        assertTableEquals(expect2, ungroup2);
+    }
+
+    public void testUngroupRollingGroupTimed() throws ExecutionException, InterruptedException, TimeoutException {
+        final Instant baseTime = DateTimeUtils.parseInstant("2025-01-01T09:30:00 NY");
+        final Duration rev = Duration.ofSeconds(15);
+        final Duration fwd = Duration.ZERO;
+
+        final QueryTable table = TstUtils.testRefreshingTable(i(2, 4, 6).toTracking(),
+                col("Sym", "a", "b", "a"),
+                instantCol("ts", baseTime, baseTime.plusSeconds(10), baseTime.plusSeconds(20)),
+                intCol("x", 1, 2, 3));
+        final Table grouped = table.updateBy(UpdateByOperation.RollingGroup("ts", rev, fwd, "x"), "Sym");
+
+        final Table expect1 = TstUtils.testTable(
+                col("Sym", "a", "b", "a"),
+                instantCol("ts", baseTime, baseTime.plusSeconds(10), baseTime.plusSeconds(20)),
+                intCol("x", 1, 2, 3))
+                .updateBy(UpdateByOperation.RollingGroup("ts", rev, fwd, "x"), "Sym").ungroup("x");
+        final Table expect2 = TstUtils.testTable(
+                col("Sym", "a", "b", "b", "a", "b"),
+                instantCol("ts", baseTime, baseTime.plusSeconds(5), baseTime.plusSeconds(10),
+                        baseTime.plusSeconds(20), baseTime.plusSeconds(30)),
+                intCol("x", 1, 4, 2, 3, 5))
+                .updateBy(UpdateByOperation.RollingGroup("ts", rev, fwd, "x"), "Sym").ungroup("x");
+
+        final Callable<Table> callable = () -> grouped.ungroup("x");
+
+        updateGraph.startCycleForUnitTests(false);
+
+        final Table ungroup1 = pool.submit(callable).get(TIMEOUT_LENGTH, TIMEOUT_UNIT);
+        assertTableEquals(expect1, ungroup1);
+
+        TstUtils.addToTable(table, i(3, 8),
+                col("Sym", "b", "b"),
+                instantCol("ts", baseTime.plusSeconds(5), baseTime.plusSeconds(30)),
+                intCol("x", 4, 5));
+        table.notifyListeners(i(3, 8), i(), i());
+        updateGraph.markSourcesRefreshedForUnitTests();
+
+        // the rolling group has not yet processed the update, so instantiation must use previous values
+        final Table ungroup2 = pool.submit(callable).get(TIMEOUT_LENGTH, TIMEOUT_UNIT);
+
+        assertTableEquals(expect1, prevTable(ungroup1));
+        assertTableEquals(expect1, prevTable(ungroup2));
+
+        updateGraph.completeCycleForUnitTests();
+
+        assertTableEquals(expect2, ungroup1);
+        assertTableEquals(expect2, ungroup2);
     }
 
     public void testUpdateView() throws ExecutionException, InterruptedException, TimeoutException {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingGroup.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingGroup.java
@@ -1086,6 +1086,43 @@ public class TestRollingGroup extends BaseUpdateByTest {
         }
     }
 
+    @Test
+    public void testUngroupTicking() {
+        doTestUngroupTicking(false);
+    }
+
+    @Test
+    public void testUngroupTickingBucketed() {
+        doTestUngroupTicking(true);
+    }
+
+    private void doTestUngroupTicking(final boolean bucketed) {
+        final int prevTicks = 100;
+        final int postTicks = 10;
+
+        final CreateResult result = createTestTable(DYNAMIC_TABLE_SIZE, bucketed, false, true, 0x31313131);
+        final QueryTable t = result.t;
+
+        final EvalNugget[] nuggets = new EvalNugget[] {
+                new EvalNugget() {
+                    @Override
+                    protected Table e() {
+                        final Table grouped = bucketed
+                                ? t.updateBy(UpdateByOperation.RollingGroup(prevTicks, postTicks, columns), "Sym")
+                                : t.updateBy(UpdateByOperation.RollingGroup(prevTicks, postTicks, columns));
+                        return grouped.ungroup(columns);
+                    }
+                }
+        };
+
+        final Random billy = new Random(0xB177B177);
+        for (int ii = 0; ii < DYNAMIC_UPDATE_STEPS; ii++) {
+            ExecutionContext.getContext().getUpdateGraph().<ControlledUpdateGraph>cast().runWithinUnitTestCycle(
+                    () -> GenerateTableUpdates.generateTableUpdates(DYNAMIC_UPDATE_SIZE, billy, t, result.infos));
+            TstUtils.validate("Table - step " + ii, nuggets);
+        }
+    }
+
     // endregion
 
     // region Edge cases


### PR DESCRIPTION
An audit of RowSet usage outside engine/rowset found loops calling per-element get(position)/find(key) (each an O(log n) search) where bulk operations amortize the cost:

- SerialColumnIterator: rowSet.get(position++) per element -> retained SearchIterator, with close() to release it
- UngroupedAggregateSlicedColumnSource.fillChunk: per-row get -> one in-place getKeysForPositions per group run, matching the Range/plain siblings
- BaseAggregateSlicedColumnSource: add chunked getUngroupedSize/getUngroupedPrevSize overrides so ungroup sizing does not fall back to per-row scalar iteration
- StaticNaturalJoinStateManager.buildRowRedirection: drop per-row getRowSet().get(...) whose argument was a row key rather than a position (result discarded except under EXACTLY_ONE_MATCH)
- StaticHashedNaturalJoinStateManager.buildIndexedRowRedirection: per-group indexTableRowSet.get(ii) -> lockstep RowSet.Iterator; checkExactMatch now receives the index-table row key

Note: the StaticHashedNaturalJoinStateManager hunks overlap with #8484 (DH-23591); whichever lands second needs a trivial rebase.