### PR TITLE
ci: no-ticket: Allow 3 gradle workers on standard 16GiB runners.

### DIFF
--- a/.github/scripts/gradle-properties.sh
+++ b/.github/scripts/gradle-properties.sh
@@ -13,8 +13,9 @@ OTHER_BYTES=2147483648
 TOTAL_SYSTEM_BYTES="$(free --bytes | grep Mem | awk -F " " '{print $2}')"
 
 # This is accounting for "worst case", assuming every single worker is using the theoretical maximum.
-# Currently, engine/table/build.gradle sets a heap size of 6GiB, so that's the maximum.
-PER_WORKER_BYTES=6442450944
+# Test heaps are at most 3500MiB (see engine/table/build.gradle); 4GiB covers that plus JVM overhead (metaspace, code
+# cache, GC structures, thread stacks). On the standard 16GiB GitHub runners this yields 3 workers.
+PER_WORKER_BYTES=4294967296
 
 # See https://github.com/gradle/gradle/issues/14431#issuecomment-1601724453 for why we need to have this sort of logic
 # here

--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -118,8 +118,8 @@ TestTools.addEngineParallelTest(project)
 TestTools.addEngineSerialTest(project)
 TestTools.addEngineOutOfBandTest(project)
 
-// If changing, be sure to update .github/scripts/print-gradle-workers-max.sh
-def maxHeapSize = findProperty('maxHeapSize') as String ?: '6g'
+// If changing, be sure to update PER_WORKER_BYTES in .github/scripts/gradle-properties.sh
+def maxHeapSize = findProperty('maxHeapSize') as String ?: '3500m'
 
 tasks.testParallel.maxHeapSize = maxHeapSize
 tasks.testSerial.maxHeapSize = maxHeapSize


### PR DESCRIPTION
Now that DH-23586 bounds TableUpdateValidator's sparse memory overhead, every engine/table test suite passes with a 3500m heap, so the 6g default is no longer needed. Budget workers at 4GiB (3500m heap plus JVM overhead), which raises the standard 16GiB GitHub runners from 2 workers to 3 for every CI job, including per-PR check and the nightly testOutOfBand long pole.