### PR TITLE
fix: DH-23602: Don't propagate SortedColumns through merge

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableImpl.java
@@ -210,12 +210,14 @@ public class PartitionedTableImpl extends LivenessArtifact implements Partitione
         }
 
         boolean anyPreviousTableIsRefreshing = false;
+        boolean multipleConstituents = false;
 
         Table constituent = constituents.next();
         boolean currentTableIsRefreshing = constituent.isRefreshing();
         final Map<String, Object> candidates = new HashMap<>(constituent.getAttributes());
 
         while (constituents.hasNext()) {
+            multipleConstituents = true;
             anyPreviousTableIsRefreshing |= currentTableIsRefreshing;
             constituent = constituents.next();
             currentTableIsRefreshing = constituent.isRefreshing();
@@ -232,6 +234,12 @@ public class PartitionedTableImpl extends LivenessArtifact implements Partitione
                     }
                 }
             }
+        }
+
+        if (multipleConstituents) {
+            // The concatenation of two or more sorted tables is not guaranteed to be sorted, even when the
+            // constituents agree on their sort order. Propagating the claim is incorrect.
+            candidates.remove(Table.SORTED_COLUMNS_ATTRIBUTE);
         }
 
         if (anyPreviousTableIsRefreshing) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -372,6 +372,33 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
         }
     }
 
+    public void testMergeSortedColumnsAttribute() {
+        final Table sorted = TableTools.newTable(intCol("Col0", 5, 3, 1)).sort("Col0");
+        TestCase.assertEquals("Col0=Ascending", sorted.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // A merge of a single constituent is still sorted, so the attribute may be retained.
+        final Table mergedOne = TableTools.merge(sorted);
+        TestCase.assertEquals("Col0=Ascending", mergedOne.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // The concatenation of two sorted tables is not sorted; the claim must not be propagated.
+        final Table mergedTwo = TableTools.merge(sorted, sorted);
+        TestCase.assertNull(mergedTwo.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // Sorted-column pushdown against a false claim silently drops rows; verify we get them all.
+        assertTableEquals(TableTools.newTable(intCol("Col0", 3, 5, 3, 5)), mergedTwo.where("Col0 >= 3"));
+
+        // The same must hold for a partitionBy-produced PartitionedTable whose constituents are each sorted.
+        final Table source = TableTools.newTable(
+                col("Sym", "aa", "bb", "aa", "bb"),
+                intCol("Col0", 5, 6, 3, 4));
+        final PartitionedTable partitioned = source.partitionBy("Sym")
+                .transform(t -> t.sort("Col0"));
+        for (final Table constituent : partitioned.constituents()) {
+            TestCase.assertEquals("Col0=Ascending", constituent.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+        }
+        TestCase.assertNull(partitioned.merge().getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+    }
+
     public void testJoinSanity() {
         final QueryTable left = testRefreshingTable(i(1, 2, 4, 6).toTracking(),
                 col("USym", "aa", "bb", "aa", "bb"),


### PR DESCRIPTION
`PartitionedTableImpl.merge()` copies onto the merged result every attribute its
constituents agree on. `SORTED_COLUMNS_ATTRIBUTE` was not exempted, so merging two
tables that are each sorted by `Col0` produced a result claiming `Col0=Ascending` —
a claim the concatenation does not satisfy.

That turns a true sortedness claim into a false one with no unsafe call by the caller.
`SortedColumnPushdownManager` then binary-searches the merged table against the false
claim, and range and match filters silently return wrong rows. On a merge of two copies
of a 10k-row sorted table, `where("Col0 >= 9000")` returned 11,000 rows instead of 2,000,
with no error or warning.

`computeSharedAttributes` now drops `SORTED_COLUMNS_ATTRIBUTE` whenever there is more
than one constituent.

Notes on scope:

- A single-constituent merge is still genuinely sorted, so the attribute is retained
  there. This keeps `TableTools.merge(t)` behaving as before.
- The `constituentChangesPermitted` path already propagates no attributes at all and is
  unaffected.
- Merged tables that previously advertised sortedness no longer do. For in-memory
  constituents this gives up the table-level binary search in exchange for correct
  results — constituent sortedness is not currently consulted during union pushdown,
  since `UnionSourcePushdownFilterContext` builds its per-constituent matchers without
  `SortedColumnPushdownManager.wrap`. Recovering that is a separate improvement.
- Parquet-backed constituents are unaffected in practice: their binary search runs at the
  region level off per-file metadata sort columns, not off the merged table's attribute.
