### PR TITLE
fix!: DH-23606: Reject shift windows that lie outside the key space

### DIFF
--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java
@@ -126,6 +126,61 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
     }
 
     /**
+     * Whether a shift window is a range of keys that lies within the key space both before and after the shift. Row
+     * keys are non-negative, so a window that ends before it begins, begins below zero, or whose post-shift image
+     * begins below zero or ends past {@link Long#MAX_VALUE}, does not map its whole extent onto keys: some or all of it
+     * lies where no key can be, even if the rest of it holds keys that could move. Readers of shift data rely on
+     * {@code begin + delta} and {@code end + delta} being plain in-range sums, so the builders admit no such window; a
+     * caller with keys to move in the part inside the key space describes that part.
+     */
+    private static boolean withinKeySpace(final long beginRange, final long endRange, final long shiftDelta) {
+        if (beginRange < 0 || endRange < beginRange) {
+            return false;
+        }
+        // beginRange is non-negative, so beginRange + shiftDelta cannot overflow when shiftDelta is negative; endRange
+        // is non-negative, so Long.MAX_VALUE - endRange cannot overflow when shiftDelta is positive.
+        return shiftDelta < 0 ? beginRange + shiftDelta >= 0 : shiftDelta <= Long.MAX_VALUE - endRange;
+    }
+
+    /**
+     * Rejects a shift window that is not a range of keys within the key space before and after the shift; see
+     * {@link #withinKeySpace}.
+     *
+     * @throws IllegalArgumentException if the window ends before it begins, or any part of it lies outside the key
+     *         space before or after the shift
+     */
+    private static void checkWithinKeySpace(final long beginRange, final long endRange, final long shiftDelta) {
+        if (endRange < beginRange) {
+            throw new IllegalArgumentException(
+                    "range [" + beginRange + "," + endRange + "]->" + shiftDelta + " ends before it begins");
+        }
+        if (!withinKeySpace(beginRange, endRange, shiftDelta)) {
+            throw new IllegalArgumentException("range [" + beginRange + "," + endRange + "]->" + shiftDelta
+                    + " lies outside the key space [0," + Long.MAX_VALUE + "] before or after the shift");
+        }
+    }
+
+    /**
+     * Rejects an offset that carries the window at {@code idx} outside the key space, before or after its shift. The
+     * builders keep every window inside the key space, so only the offset can carry one out, and an offset that does is
+     * the caller's error whatever rowset the shifts are being applied to.
+     *
+     * @throws IllegalArgumentException if the offset window lies outside the key space before or after the shift
+     */
+    private void checkOffsetWindow(final int idx, final long offset) {
+        final long beginRange = getBeginRange(idx);
+        final long endRange = getEndRange(idx);
+        final long offsetBegin = beginRange + offset;
+        final long offsetEnd = endRange + offset;
+        if (((beginRange ^ offsetBegin) & (offset ^ offsetBegin)) < 0
+                || ((endRange ^ offsetEnd) & (offset ^ offsetEnd)) < 0) {
+            throw new IllegalArgumentException("offset " + offset + " carries range [" + beginRange + "," + endRange
+                    + "]->" + getShiftDelta(idx) + " outside the key space");
+        }
+        checkWithinKeySpace(offsetBegin, offsetEnd, getShiftDelta(idx));
+    }
+
+    /**
      * Verify invariants of internal data structures hold.
      */
     public void validate() {
@@ -134,6 +189,8 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
         for (int idx = 0; idx < size; ++idx) {
             Assert.leq(getBeginRange(idx), "getBeginRange(idx)", getEndRange(idx), "getEndRange(idx)");
             Assert.neqZero(getShiftDelta(idx), "getShiftDelta(idx)");
+            Assert.assertion(withinKeySpace(getBeginRange(idx), getEndRange(idx), getShiftDelta(idx)),
+                    "withinKeySpace(getBeginRange(idx), getEndRange(idx), getShiftDelta(idx))");
 
             if (idx == 0) {
                 continue;
@@ -350,9 +407,12 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
      * @param endRange end of range (inclusive)
      * @param shiftDelta amount range has moved by
      * @return Whether there was any overlap found to shift
+     * @throws IllegalArgumentException if the range ends before it begins, or any part of it lies outside the key space
+     *         before or after the shift
      */
     public static boolean applyShift(@NotNull final WritableRowSet rowSet, final long beginRange, final long endRange,
             final long shiftDelta) {
+        checkWithinKeySpace(beginRange, endRange, shiftDelta);
         try (final WritableRowSet toShift = rowSet.subSetByKeyRange(beginRange, endRange)) {
             if (toShift.isEmpty()) {
                 return false;
@@ -377,25 +437,8 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
             final int size = size();
             for (int idx = 0; idx < size; ++idx) {
                 final long shiftDelta = getShiftDelta(idx);
-                // A window may reach past either end of the key space: a shift is valid as long as no key would
-                // actually land there, so that part of the window is empty and only the rest is a range of keys.
-                final long preShiftBegin = getBeginRange(idx);
-                final long preShiftEnd = getEndRange(idx);
-                long beginRange = preShiftBegin + shiftDelta;
-                long endRange = preShiftEnd + shiftDelta;
-                if (shiftDelta > 0) {
-                    if (beginRange < preShiftBegin) {
-                        continue; // the whole window lies past Long.MAX_VALUE
-                    }
-                    if (endRange < preShiftEnd) {
-                        endRange = Long.MAX_VALUE;
-                    }
-                } else {
-                    if (endRange < 0) {
-                        continue; // the whole window lies below zero
-                    }
-                    beginRange = Math.max(beginRange, 0);
-                }
+                final long beginRange = getBeginRange(idx) + shiftDelta;
+                final long endRange = getEndRange(idx) + shiftDelta;
 
                 if (!rsIt.advance(beginRange)) {
                     break;
@@ -421,8 +464,15 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
      * @param rowSet The {@link WritableRowSet} to shift
      * @param offset An additional offset to apply to all shifts (such as when applying to a wrapped table)
      * @return {@code rowSet}
+     * @throws IllegalArgumentException if the offset carries a shift window outside the key space
      */
     public WritableRowSet unapply(final WritableRowSet rowSet, final long offset) {
+        final int size = size();
+        // Every window is checked before any of the rowset is read, so the rejection does not depend on how far into
+        // the shifts the rowset reaches.
+        for (int idx = 0; idx < size; ++idx) {
+            checkOffsetWindow(idx, offset);
+        }
         // Accumulate what moves and put it back in two set operations, rather than one subset/remove/shift/insert per
         // shift range: each of those touches the whole rowset, so doing them one at a time costs the number of shifts
         // times the rowset's length. The windows are ordered and disjoint in both keyspaces (see validate()), so the
@@ -431,34 +481,12 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
         final RowSetBuilderSequential toRemove = RowSetFactory.builderSequential();
         final RowSetBuilderSequential toInsert = RowSetFactory.builderSequential();
         try (final RowSequence.Iterator rsIt = rowSet.getRowSequenceIterator()) {
-            final int size = size();
             for (int idx = 0; idx < size; ++idx) {
                 final long shiftDelta = getShiftDelta(idx);
-                // The window sits in post-shift keyspace, plus the caller's offset; what it holds moves back by the
-                // delta, which the offset does not touch. A window may reach past either end of the key space, where
-                // there are no keys.
-                final long shift = shiftDelta + offset;
-                if (((shiftDelta ^ shift) & (offset ^ shift)) < 0) {
-                    // The combined shift itself overflowed: the window lies wholly outside the key space.
-                    continue;
-                }
-                final long preShiftBegin = getBeginRange(idx);
-                final long preShiftEnd = getEndRange(idx);
-                long beginRange = preShiftBegin + shift;
-                long endRange = preShiftEnd + shift;
-                if (shift > 0) {
-                    if (beginRange < preShiftBegin) {
-                        continue; // the whole window lies past Long.MAX_VALUE
-                    }
-                    if (endRange < preShiftEnd) {
-                        endRange = Long.MAX_VALUE;
-                    }
-                } else {
-                    if (endRange < 0) {
-                        continue; // the whole window lies below zero
-                    }
-                    beginRange = Math.max(beginRange, 0);
-                }
+                // The window sits in the caller's key space, offset from the one the shifts were built in; what it
+                // holds moves back by the delta, which the offset does not touch.
+                final long beginRange = getBeginRange(idx) + offset + shiftDelta;
+                final long endRange = getEndRange(idx) + offset + shiftDelta;
 
                 if (!rsIt.advance(beginRange)) {
                     break;
@@ -489,9 +517,12 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
      * @param endRange end of range (inclusive)
      * @param shiftDelta amount range has moved by
      * @return Whether there was any overlap found to shift
+     * @throws IllegalArgumentException if the range ends before it begins, or any part of it lies outside the key space
+     *         before or after the shift
      */
     public static boolean unapplyShift(@NotNull final WritableRowSet rowSet, final long beginRange, final long endRange,
             final long shiftDelta) {
+        checkWithinKeySpace(beginRange, endRange, shiftDelta);
         try (final WritableRowSet toShift = rowSet.subSetByKeyRange(beginRange + shiftDelta, endRange + shiftDelta)) {
             if (toShift.isEmpty()) {
                 return false;
@@ -727,9 +758,17 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
          * @param beginRange first key to shift (inclusive)
          * @param endRange last key to shift (inclusive)
          * @param shiftDelta offset to shift by; may be negative
+         * @throws IllegalArgumentException if the range overlaps a previous shift in either key space, or any part of
+         *         it lies outside the key space before or after the shift
          */
         public void shiftRange(final long beginRange, final long endRange, final long shiftDelta) {
-            if (shiftDelta == 0 || endRange < beginRange) {
+            if (endRange < beginRange) {
+                // An empty range holds no keys and records nothing; callers that walk sub-ranges of a table's key
+                // space produce these where two boundaries meet.
+                return;
+            }
+            checkWithinKeySpace(beginRange, endRange, shiftDelta);
+            if (shiftDelta == 0) {
                 return;
             }
 
@@ -979,9 +1018,17 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
          * @param beginRange first key to shift (inclusive)
          * @param endRange last key to shift (inclusive)
          * @param shiftDelta offset to shift by; may be negative
+         * @throws IllegalArgumentException if the range overlaps a previous shift in either key space, or any part of
+         *         it lies outside the key space before or after the shift
          */
         public void shiftRange(final long beginRange, final long endRange, final long shiftDelta) {
-            if (shiftDelta == 0 || endRange < beginRange) {
+            if (endRange < beginRange) {
+                // An empty range holds no keys and records nothing; callers that walk sub-ranges of a table's key
+                // space produce these where two boundaries meet.
+                return;
+            }
+            checkWithinKeySpace(beginRange, endRange, shiftDelta);
+            if (shiftDelta == 0) {
                 return;
             }
 

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/RowSetShiftDataKeySpaceTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/RowSetShiftDataKeySpaceTest.java
@@ -1,0 +1,199 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.rowset;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Row keys are non-negative, so a shift window that begins below zero, or whose post-shift image begins below zero or
+ * ends past {@link Long#MAX_VALUE}, does not map its whole extent onto keys, even when the rest of it holds keys that
+ * could move. Both builders reject the whole window with an {@link IllegalArgumentException} rather than storing it,
+ * which lets readers of shift data add {@code begin + delta} and {@code end + delta} without guarding against overflow.
+ * Windows that end exactly at either edge of the key space are valid.
+ */
+public class RowSetShiftDataKeySpaceTest {
+
+    private static final long MAX = Long.MAX_VALUE;
+
+    private static RowSetShiftData.SmartCoalescingBuilder smartBuilder() {
+        return new RowSetShiftData.SmartCoalescingBuilder(RowSetFactory.fromRange(0, MAX));
+    }
+
+    @Test
+    public void testBuilderRejectsWindowBeginningBelowZero() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(-5, 10, 3));
+    }
+
+    /** A zero delta moves nothing, but the range is still checked before it is discarded. */
+    @Test
+    public void testBuilderRejectsWindowBeginningBelowZeroWithZeroDelta() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(-1, 5, 0));
+    }
+
+    @Test
+    public void testBuilderRejectsShiftBelowZero() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(0, 300, -3));
+    }
+
+    @Test
+    public void testBuilderRejectsShiftPastMaximum() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(MAX - 400, MAX, 3));
+    }
+
+    @Test
+    public void testBuilderRejectsShiftPastMaximumByFullRange() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(10, 20, MAX));
+    }
+
+    @Test
+    public void testBuilderAcceptsShiftLandingOnZero() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(3, 300, -3);
+        final RowSetShiftData shiftData = builder.build();
+        shiftData.validate();
+        assertEquals("{[3,300]-3}", shiftData.toString());
+    }
+
+    @Test
+    public void testBuilderAcceptsShiftLandingOnMaximum() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(MAX - 400, MAX - 3, 3);
+        final RowSetShiftData shiftData = builder.build();
+        shiftData.validate();
+        assertEquals("{[" + (MAX - 400) + "," + (MAX - 3) + "]+3}", shiftData.toString());
+    }
+
+    @Test
+    public void testSmartCoalescingBuilderRejectsWindowBeginningBelowZero() {
+        try (final RowSetShiftData.SmartCoalescingBuilder builder = smartBuilder()) {
+            assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(-5, 10, 3));
+        }
+    }
+
+    @Test
+    public void testSmartCoalescingBuilderRejectsWindowBeginningBelowZeroWithZeroDelta() {
+        try (final RowSetShiftData.SmartCoalescingBuilder builder = smartBuilder()) {
+            assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(-1, 5, 0));
+        }
+    }
+
+    @Test
+    public void testSmartCoalescingBuilderRejectsShiftBelowZero() {
+        try (final RowSetShiftData.SmartCoalescingBuilder builder = smartBuilder()) {
+            assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(0, 300, -3));
+        }
+    }
+
+    @Test
+    public void testSmartCoalescingBuilderRejectsShiftPastMaximum() {
+        try (final RowSetShiftData.SmartCoalescingBuilder builder = smartBuilder()) {
+            assertThrows(IllegalArgumentException.class, () -> builder.shiftRange(MAX - 400, MAX, 3));
+        }
+    }
+
+    @Test
+    public void testSmartCoalescingBuilderAcceptsShiftLandingOnMaximum() {
+        try (final RowSetShiftData.SmartCoalescingBuilder builder = smartBuilder()) {
+            builder.shiftRange(MAX - 400, MAX - 3, 3);
+            final RowSetShiftData shiftData = builder.build();
+            shiftData.validate();
+            assertEquals("{[" + (MAX - 400) + "," + (MAX - 3) + "]+3}", shiftData.toString());
+        }
+    }
+
+    /** Offsetting the window itself overflows. */
+    @Test
+    public void testUnapplyRejectsOffsetOverflowingTheWindow() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(100, 300, 3);
+        final RowSetShiftData shiftData = builder.build();
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(103, 303)) {
+            assertThrows(IllegalArgumentException.class, () -> shiftData.unapply(rowSet, MAX));
+        }
+    }
+
+    /** The offset window fits, but its post-shift image ends past the maximum. */
+    @Test
+    public void testUnapplyRejectsOffsetCarryingTheShiftPastMaximum() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(100, 300, 3);
+        final RowSetShiftData shiftData = builder.build();
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(103, 303)) {
+            assertThrows(IllegalArgumentException.class, () -> shiftData.unapply(rowSet, MAX - 301));
+        }
+    }
+
+    /** The offset window begins below zero, though its post-shift image does not. */
+    @Test
+    public void testUnapplyRejectsOffsetCarryingTheWindowBelowZero() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(100, 300, 3);
+        final RowSetShiftData shiftData = builder.build();
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(2, 202)) {
+            assertThrows(IllegalArgumentException.class, () -> shiftData.unapply(rowSet, -101));
+        }
+    }
+
+    @Test
+    public void testUnapplyAcceptsOffsetLandingTheWindowOnZero() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(100, 300, 3);
+        final RowSetShiftData shiftData = builder.build();
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(3, 203);
+                final WritableRowSet expected = RowSetFactory.fromRange(0, 200)) {
+            shiftData.unapply(rowSet, -100);
+            assertEquals(expected, rowSet);
+        }
+    }
+
+    @Test
+    public void testStaticApplyShiftRejectsShiftPastMaximum() {
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(MAX - 300, MAX - 100)) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> RowSetShiftData.applyShift(rowSet, MAX - 400, MAX, 3));
+        }
+    }
+
+    @Test
+    public void testStaticUnapplyShiftRejectsShiftBelowZero() {
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(97, 297)) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> RowSetShiftData.unapplyShift(rowSet, 0, 300, -3));
+        }
+    }
+
+    @Test
+    public void testStaticApplyShiftRejectsRangeEndingBeforeItBegins() {
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(100, 300)) {
+            assertThrows(IllegalArgumentException.class, () -> RowSetShiftData.applyShift(rowSet, 300, 100, 3));
+        }
+    }
+
+    @Test
+    public void testStaticUnapplyShiftRejectsRangeEndingBeforeItBegins() {
+        try (final WritableRowSet rowSet = RowSetFactory.fromRange(103, 303)) {
+            assertThrows(IllegalArgumentException.class, () -> RowSetShiftData.unapplyShift(rowSet, 300, 100, 3));
+        }
+    }
+
+    /** The rowset ends before the first window, so no traversal reaches the second; the offset is rejected anyway. */
+    @Test
+    public void testUnapplyRejectsOffsetForWindowBeyondTheRowSet() {
+        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+        builder.shiftRange(100, 200, 3);
+        builder.shiftRange(MAX - 500, MAX - 400, 3);
+        final RowSetShiftData shiftData = builder.build();
+        try (final WritableRowSet rowSet = RowSetFactory.empty()) {
+            assertThrows(IllegalArgumentException.class, () -> shiftData.unapply(rowSet, 400));
+        }
+    }
+}

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RowSetNegativeStartKeyTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RowSetNegativeStartKeyTest.java
@@ -6,7 +6,6 @@ package io.deephaven.engine.rowset.impl;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.RowSetShiftData;
 import io.deephaven.engine.rowset.WritableRowSet;
 import org.junit.Test;
 
@@ -126,82 +125,6 @@ public class RowSetNegativeStartKeyTest {
                     assertTrue(name + " shifted advance(0) keeps going", it.advance(0));
                     assertEquals(name + " shifted advance(0) is a no-op", 1100L, it.peekNextKey());
                 }
-            }
-        }
-    }
-
-    @Test
-    public void testUnapplyingAShiftWhoseWindowReachesBelowZero() {
-        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
-        builder.shiftRange(0, 300, -3);
-        final RowSetShiftData shiftData = builder.build();
-        for (final Supplier<?> supplier : rowSets()) {
-            try (final WritableRowSet rs = (WritableRowSet) supplier.get();
-                    final WritableRowSet expected = rs.copy();
-                    final WritableRowSet postShift = rs.shift(-3)) {
-                final String name = nameOf(rs);
-                shiftData.unapply(postShift);
-                postShift.validate();
-                assertEquals(name + " unapply", keysOf(expected), keysOf(postShift));
-            }
-            try (final WritableRowSet rs = (WritableRowSet) supplier.get();
-                    final WritableRowSet expected = rs.copy();
-                    final WritableRowSet postShift = rs.shift(-3)) {
-                final String name = nameOf(rs);
-                shiftData.unapply(postShift, 0);
-                postShift.validate();
-                assertEquals(name + " unapply with offset", keysOf(expected), keysOf(postShift));
-            }
-        }
-    }
-
-    /** The same shape as {@link #rowSets()}, at the top of the key space. */
-    private static Supplier<?>[] highRowSets() {
-        final long m = Long.MAX_VALUE;
-        return new Supplier<?>[] {
-                () -> singleRangeOf(m - 300, m - 100),
-                () -> sortedRangesOf(new long[] {m - 300, m - 300}, new long[] {m - 250, m - 150},
-                        new long[] {m - 100, m - 100}),
-                () -> rspOf(new long[] {m - 300, m - 300}, new long[] {m - 250, m - 150},
-                        new long[] {m - 100, m - 100}),
-        };
-    }
-
-    /**
-     * The mirror image at the top of the key space: a positive shift whose window ends at Long.MAX_VALUE has a
-     * post-shift window that wraps, and only the part past the maximum is empty.
-     */
-    @Test
-    public void testUnapplyingAShiftWhoseWindowReachesPastTheMaximum() {
-        final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
-        builder.shiftRange(Long.MAX_VALUE - 400, Long.MAX_VALUE, 3);
-        final RowSetShiftData shiftData = builder.build();
-        for (final Supplier<?> supplier : highRowSets()) {
-            try (final WritableRowSet rs = (WritableRowSet) supplier.get();
-                    final WritableRowSet expected = rs.copy();
-                    final WritableRowSet postShift = rs.shift(3)) {
-                final String name = nameOf(rs);
-                shiftData.unapply(postShift);
-                postShift.validate();
-                assertEquals(name + " unapply past max", keysOf(expected), keysOf(postShift));
-            }
-            try (final WritableRowSet rs = (WritableRowSet) supplier.get();
-                    final WritableRowSet expected = rs.copy();
-                    final WritableRowSet postShift = rs.shift(3)) {
-                final String name = nameOf(rs);
-                shiftData.unapply(postShift, 0);
-                postShift.validate();
-                assertEquals(name + " unapply past max with offset", keysOf(expected), keysOf(postShift));
-            }
-            try (final WritableRowSet rs = (WritableRowSet) supplier.get();
-                    final WritableRowSet postShift = rs.shift(3);
-                    final WritableRowSet untouched = postShift.copy()) {
-                // An offset that carries the whole window past the maximum, so far that the combined shift itself
-                // wraps: nothing in the key space is affected.
-                final String name = nameOf(rs);
-                shiftData.unapply(postShift, Long.MAX_VALUE);
-                postShift.validate();
-                assertEquals(name + " unapply with an overflowing offset", keysOf(untouched), keysOf(postShift));
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/RowSetShiftDataTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/RowSetShiftDataTest.java
@@ -62,15 +62,15 @@ public class RowSetShiftDataTest {
     @Test(expected = IllegalArgumentException.class)
     public void testPostOverlapNegativeShifts() {
         final RowSetShiftData.Builder builder = newBuilder();
-        builder.shiftRange(0, 9, -20);
-        builder.shiftRange(10, 19, -21);
+        builder.shiftRange(100, 109, -20);
+        builder.shiftRange(110, 119, -21);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testPostCrossNegativeShifts() {
         final RowSetShiftData.Builder builder = newBuilder();
-        builder.shiftRange(0, 9, -10);
-        builder.shiftRange(10, 19, -100);
+        builder.shiftRange(100, 109, -10);
+        builder.shiftRange(110, 119, -100);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -1212,7 +1212,7 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
             TstUtils.addToTable(queryTable, i(5, 7), col("intCol", 10, 12));
 
             final RowSetShiftData.Builder shiftBuilder = new RowSetShiftData.Builder();
-            shiftBuilder.shiftRange(0, 12, -5);
+            shiftBuilder.shiftRange(5, 12, -5);
 
             queryTable.notifyListeners(new TableUpdateImpl(
                     RowSetFactory.empty(),


### PR DESCRIPTION
Resolves DH-23606.

`RowSetShiftData` builders accepted a shift window whose pre-shift or post-shift image lay partly or wholly outside the key space `[0, Long.MAX_VALUE]`. Such a window does not map its whole extent onto keys, and every reader of shift data adds `begin + delta` and `end + delta` with plain arithmetic, so the window either wrapped silently (`unapply(RowKeyRangeShiftCallback)`, `extractParallelShiftedRowsFromPostShiftRowSet`, the static `applyShift`/`unapplyShift`) or had to be clamped per reader (the two `unapply(WritableRowSet)` variants, since #8454).

This change rejects the window at the source instead:

- `Builder.shiftRange` and `SmartCoalescingBuilder.shiftRange` throw `IllegalArgumentException` when any part of the window lies outside the key space before or after the shift. `appendShiftData` and the coalescing paths go through `shiftRange`, so they are covered.
- `validate()` asserts the same invariant.
- `unapply(WritableRowSet, long offset)` throws when the caller's offset carries a window outside the key space; the static `applyShift`/`unapplyShift` throw for an out-of-space window instead of silently moving nothing.
- The clamping in both `unapply(WritableRowSet)` variants is removed. All readers keep plain arithmetic, which the builders now make safe.

**Breaking change.** Code that built shift data with windows reaching past either edge of the key space, relying on the part outside being empty, now gets an `IllegalArgumentException` at build time. No producer in the engine, the Barrage reader, or the test update generator does this: every call site bounds its windows by actual keys, slot offsets, or sizes.

Testing: `RowSetShiftDataKeySpaceTest` (21 single-case methods) covers both builders including a zero-delta range with a negative begin, the offset `unapply` including an offset whose invalid window lies beyond the rowset, and the static helpers, which also reject a range that ends before it begins. The two tests in `RowSetNegativeStartKeyTest` that asserted the old tolerant behaviour are removed, and two fixtures elsewhere now describe their windows within the key space: the negative-shift overlap cases in engine-table's `RowSetShiftDataTest`, and the `[0,12]` by `-5` shift in server's `BarrageMessageRoundTripTest.testUsePrevOnSnapshot`, which becomes `[5,12]`. `engine-rowset` and `engine-table` pass `test` and `testOutOfBand` with no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSoNN3AjPaj9Pi1dP5P6h2
