### PR TITLE
fix: DH-23602: Don't propagate SortedColumns through merge

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableImpl.java
@@ -210,12 +210,14 @@ public class PartitionedTableImpl extends LivenessArtifact implements Partitione
         }
 
         boolean anyPreviousTableIsRefreshing = false;
+        boolean multipleConstituents = false;
 
         Table constituent = constituents.next();
         boolean currentTableIsRefreshing = constituent.isRefreshing();
         final Map<String, Object> candidates = new HashMap<>(constituent.getAttributes());
 
         while (constituents.hasNext()) {
+            multipleConstituents = true;
             anyPreviousTableIsRefreshing |= currentTableIsRefreshing;
             constituent = constituents.next();
             currentTableIsRefreshing = constituent.isRefreshing();
@@ -232,6 +234,12 @@ public class PartitionedTableImpl extends LivenessArtifact implements Partitione
                     }
                 }
             }
+        }
+
+        if (multipleConstituents) {
+            // The concatenation of two or more sorted tables is not guaranteed to be sorted, even when the
+            // constituents agree on their sort order. Propagating the claim is incorrect.
+            candidates.remove(Table.SORTED_COLUMNS_ATTRIBUTE);
         }
 
         if (anyPreviousTableIsRefreshing) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -372,6 +372,33 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
         }
     }
 
+    public void testMergeSortedColumnsAttribute() {
+        final Table sorted = TableTools.newTable(intCol("Col0", 5, 3, 1)).sort("Col0");
+        TestCase.assertEquals("Col0=Ascending", sorted.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // A merge of a single constituent is still sorted, so the attribute may be retained.
+        final Table mergedOne = TableTools.merge(sorted);
+        TestCase.assertEquals("Col0=Ascending", mergedOne.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // The concatenation of two sorted tables is not sorted; the claim must not be propagated.
+        final Table mergedTwo = TableTools.merge(sorted, sorted);
+        TestCase.assertNull(mergedTwo.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+
+        // Sorted-column pushdown against a false claim silently drops rows; verify we get them all.
+        assertTableEquals(TableTools.newTable(intCol("Col0", 3, 5, 3, 5)), mergedTwo.where("Col0 >= 3"));
+
+        // The same must hold for a partitionBy-produced PartitionedTable whose constituents are each sorted.
+        final Table source = TableTools.newTable(
+                col("Sym", "aa", "bb", "aa", "bb"),
+                intCol("Col0", 5, 6, 3, 4));
+        final PartitionedTable partitioned = source.partitionBy("Sym")
+                .transform(t -> t.sort("Col0"));
+        for (final Table constituent : partitioned.constituents()) {
+            TestCase.assertEquals("Col0=Ascending", constituent.getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+        }
+        TestCase.assertNull(partitioned.merge().getAttribute(Table.SORTED_COLUMNS_ATTRIBUTE));
+    }
+
     public void testJoinSanity() {
         final QueryTable left = testRefreshingTable(i(1, 2, 4, 6).toTracking(),
                 col("USym", "aa", "bb", "aa", "bb"),


### PR DESCRIPTION
Cherry-pick of 0dfe67b9aedd923a0471433bddf9be301a28755e from `main`.

Original PR: https://github.com/deephaven/deephaven-core/pull/8488