### PR TITLE
fix: DH-23612: Prepare indirect sort kernels even when the sort has a data index.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SortOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SortOperation.java
@@ -110,11 +110,13 @@ public class SortOperation implements QueryTable.MemoizableOperation<QueryTable>
         // This sort operation might leverage a data index.
         dataIndex = optimalIndex(parent);
 
-        if (QueryTable.USE_INDIRECT_SORT_KERNELS && dataIndex == null) {
+        if (QueryTable.USE_INDIRECT_SORT_KERNELS) {
             // Resolve (compiling on demand if necessary) the multi-column sort kernel for this sort now, while we
             // are on a thread whose ExecutionContext has a QueryCompiler; the sort listener may otherwise be the
-            // first to need it, on an update graph thread that cannot compile. For an initially empty table (a
-            // refreshing blink table, for instance) the listener is always first.
+            // first to need it, on an update graph thread that cannot compile. This is required even when this sort
+            // has a data index: the index accelerates the initial sort, but the listener's incremental sorts of
+            // added and modified rows do not use it. For an initially empty table (a refreshing blink table, for
+            // instance) the listener is always first.
             SortHelpers.prepareSortKernel(sortOrder, sortColumns, comparators, comparatorsRespectEquality);
         }
     }


### PR DESCRIPTION
SortOperation only pre-resolved the multi-column sort kernel when it had no data index, on the theory that indexed sorts do not need it. The index only accelerates the initial sort, though: SortListener's incremental sorts of added and modified rows go through the kernel path regardless. When an indexed multi-column sort was constructed in a JVM where nothing else had compiled that kernel shape, the first incremental update tried to compile it on an update graph thread - whose ExecutionContext has no QueryCompiler - and the listener died with ExecutionContextRegistrationException, poisoning the update graph.

Prepare the kernel at construction whenever indirect kernels are enabled.

Fixes [DH-23612](https://deephaven.atlassian.net/browse/DH-23612).

[DH-23612]: https://deephaven.atlassian.net/browse/DH-23612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ