### PR TITLE
fix: DH-23613: Validate rollup aggregation column expressions

### DIFF
--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -185,11 +185,16 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
     private static Table makeRollupFormulaPrototype(
             @NotNull final Table sourceTable,
             @NotNull final Collection<ColumnName> groupByColumns) {
+        final String depthName = AggregationProcessor.ROLLUP_FORMULA_DEPTH.name();
+        final String keysName = AggregationProcessor.ROLLUP_FORMULA_KEYS.name();
         final Table grouped = TableTools.newTable(sourceTable.getDefinition()).groupBy(groupByColumns);
-        final List<ColumnDefinition<?>> definitions = new ArrayList<>(grouped.getDefinition().getColumns());
-        definitions.add(ColumnDefinition.ofInt(AggregationProcessor.ROLLUP_FORMULA_DEPTH.name()));
-        definitions.add(ColumnDefinition.of(
-                AggregationProcessor.ROLLUP_FORMULA_KEYS.name(), ObjectVector.type(StringType.of())));
+        // Mirror the engine's putAll(extraColumns): the synthetic columns replace any same-named source columns, so
+        // drop those names before appending to avoid a duplicate-name failure in TableDefinition.of.
+        final List<ColumnDefinition<?>> definitions = grouped.getDefinition().getColumnStream()
+                .filter(cd -> !cd.getName().equals(depthName) && !cd.getName().equals(keysName))
+                .collect(Collectors.toCollection(ArrayList::new));
+        definitions.add(ColumnDefinition.ofInt(depthName));
+        definitions.add(ColumnDefinition.of(keysName, ObjectVector.type(StringType.of())));
         return TableTools.newTable(TableDefinition.of(definitions));
     }
 

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -147,15 +147,22 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
      * Run the user-supplied expressions in a rollup's aggregations through the {@link ColumnExpressionValidator},
      * mirroring the validation {@code AggregateGrpcImpl} performs for {@code TableService/Aggregate}. Only the two
      * rollup aggregation kinds that compile user expressions need checking: {@code AggCountWhere} (filters, compiled
-     * against the source definition) and {@code AggFormula} (a formula selectable, compiled against the grouped
-     * rollup-formula prototype). {@code AggSpecFormula} is unsupported in rollups, so it never reaches compilation.
+     * against the source definition) and {@code AggFormula} (a formula selectable). {@code AggSpecFormula} is
+     * unsupported in rollups, so it never reaches compilation.
+     * <p>
+     * A rollup compiles each formula once per level: {@code RollupTableImpl.rollupFromBase} reaggregates by
+     * progressively shorter prefixes of the group-by columns (base level down to the empty-key root), and
+     * {@code AggregationProcessor.prepareFormula} exposes every non-key column as a vector. Since that changes which
+     * overload a method call resolves to (e.g. {@code String.compareTo} at a level where a key is scalar vs a vector
+     * method once that key is dropped), each formula must be validated against every grouping prefix, not just the
+     * base.
      */
     private void validateRollupAggregations(
             @NotNull final List<io.deephaven.proto.backplane.grpc.Aggregation> aggregations,
             @NotNull final Table sourceTable,
             @NotNull final Collection<ColumnName> groupByColumns) {
-        // Built lazily; only needed (and only well-defined) when a formula aggregation is present.
-        Table formulaPrototype = null;
+        // The per-level prototype definitions, shared across all formula aggregations; built lazily on first use.
+        List<TableDefinition> formulaPrototypes = null;
         for (final io.deephaven.proto.backplane.grpc.Aggregation agg : aggregations) {
             if (agg.hasCountWhere()) {
                 columnExpressionValidator.validateSelectFilters(
@@ -164,23 +171,44 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             } else if (agg.hasFormula()) {
                 final io.deephaven.proto.backplane.grpc.Selectable selectableGrpc = agg.getFormula().getSelectable();
                 if (selectableGrpc.getTypeCase() == io.deephaven.proto.backplane.grpc.Selectable.TypeCase.RAW) {
-                    if (formulaPrototype == null) {
-                        formulaPrototype = makeRollupFormulaPrototype(sourceTable, groupByColumns);
+                    if (formulaPrototypes == null) {
+                        formulaPrototypes = makeRollupFormulaPrototypes(sourceTable, groupByColumns);
                     }
                     final String raw = selectableGrpc.getRaw();
-                    final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(raw));
-                    columnExpressionValidator.validateColumnExpressions(
-                            new SelectColumn[] {selectColumn}, new String[] {raw}, formulaPrototype.getDefinition());
+                    for (final TableDefinition prototype : formulaPrototypes) {
+                        // A fresh SelectColumn per prototype; validateColumnExpressions initializes it against the
+                        // definition, which is stateful and must not be shared across levels.
+                        final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(raw));
+                        columnExpressionValidator.validateColumnExpressions(
+                                new SelectColumn[] {selectColumn}, new String[] {raw}, prototype);
+                    }
                 }
             }
         }
     }
 
     /**
-     * Build the definition prototype the engine compiles a rollup formula against, matching
-     * {@code AggregationProcessor}'s rollup formula preparation: the source grouped by the group-by columns (so non-key
-     * columns are exposed as vectors), plus the engine's extra rollup formula columns ({@code __FORMULA_DEPTH__} /
-     * {@code __FORMULA_KEYS__}), which formulas are permitted to reference.
+     * Build the formula-validation prototype definition for every rollup level, from the base (grouped by all
+     * {@code groupByColumns}) down to the root (grouped by nothing). The levels mirror
+     * {@code RollupTableImpl.rollupFromBase}, which reaggregates by progressively shorter prefixes of the group-by
+     * columns.
+     */
+    private static List<TableDefinition> makeRollupFormulaPrototypes(
+            @NotNull final Table sourceTable,
+            @NotNull final Collection<ColumnName> groupByColumns) {
+        final List<ColumnName> keys = new ArrayList<>(groupByColumns);
+        final List<TableDefinition> prototypes = new ArrayList<>(keys.size() + 1);
+        for (int prefixLength = keys.size(); prefixLength >= 0; --prefixLength) {
+            prototypes.add(makeRollupFormulaPrototype(sourceTable, keys.subList(0, prefixLength)).getDefinition());
+        }
+        return prototypes;
+    }
+
+    /**
+     * Build the definition prototype the engine compiles a rollup formula against at a single level, matching
+     * {@code AggregationProcessor}'s rollup formula preparation: the source grouped by {@code groupByColumns} (so
+     * non-key columns are exposed as vectors), plus the engine's extra rollup formula columns
+     * ({@code __FORMULA_DEPTH__} / {@code __FORMULA_KEYS__}), which formulas are permitted to reference.
      */
     private static Table makeRollupFormulaPrototype(
             @NotNull final Table sourceTable,

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -170,18 +170,30 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                         sourceTable.getDefinition());
             } else if (agg.hasFormula()) {
                 final io.deephaven.proto.backplane.grpc.Selectable selectableGrpc = agg.getFormula().getSelectable();
-                if (selectableGrpc.getTypeCase() == io.deephaven.proto.backplane.grpc.Selectable.TypeCase.RAW) {
-                    if (formulaPrototypes == null) {
-                        formulaPrototypes = makeRollupFormulaPrototypes(sourceTable, groupByColumns);
+                switch (selectableGrpc.getTypeCase()) {
+                    case RAW: {
+                        if (formulaPrototypes == null) {
+                            formulaPrototypes = makeRollupFormulaPrototypes(sourceTable, groupByColumns);
+                        }
+                        final String raw = selectableGrpc.getRaw();
+                        for (final TableDefinition prototype : formulaPrototypes) {
+                            // A fresh SelectColumn per prototype; validateColumnExpressions initializes it against the
+                            // definition, which is stateful and must not be shared across levels.
+                            final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(raw));
+                            columnExpressionValidator.validateColumnExpressions(
+                                    new SelectColumn[] {selectColumn}, new String[] {raw}, prototype);
+                        }
+                        break;
                     }
-                    final String raw = selectableGrpc.getRaw();
-                    for (final TableDefinition prototype : formulaPrototypes) {
-                        // A fresh SelectColumn per prototype; validateColumnExpressions initializes it against the
-                        // definition, which is stateful and must not be shared across levels.
-                        final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(raw));
-                        columnExpressionValidator.validateColumnExpressions(
-                                new SelectColumn[] {selectColumn}, new String[] {raw}, prototype);
-                    }
+                    case TYPE_NOT_SET:
+                        // No expression is present, so there is nothing to compile or validate.
+                        break;
+                    default:
+                        // Reject unknown Selectable types rather than skipping them, so a newly added case cannot
+                        // reach the engine without passing through the validator.
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                                "Unsupported Selectable type (" + selectableGrpc.getTypeCase()
+                                        + ") in rollup Aggregation formula.");
                 }
             }
         }

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -122,7 +122,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                                 .map(AggregationAdapter::adapt)
                                 .collect(Collectors.toList());
                         final boolean includeConstituents = request.getIncludeConstituents();
-                        final Collection<ColumnName> groupByColumns = request.getGroupByColumnsList().stream()
+                        final List<ColumnName> groupByColumns = request.getGroupByColumnsList().stream()
                                 .map(ColumnName::of)
                                 .collect(Collectors.toList());
                         validateRollupAggregations(request.getAggregationsList(), sourceTable, groupByColumns);
@@ -160,7 +160,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
     private void validateRollupAggregations(
             @NotNull final List<io.deephaven.proto.backplane.grpc.Aggregation> aggregations,
             @NotNull final Table sourceTable,
-            @NotNull final Collection<ColumnName> groupByColumns) {
+            @NotNull final List<ColumnName> groupByColumns) {
         // The per-level prototype definitions, shared across all formula aggregations; built lazily on first use.
         List<TableDefinition> formulaPrototypes = null;
         for (final io.deephaven.proto.backplane.grpc.Aggregation agg : aggregations) {
@@ -207,11 +207,11 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
      */
     private static List<TableDefinition> makeRollupFormulaPrototypes(
             @NotNull final Table sourceTable,
-            @NotNull final Collection<ColumnName> groupByColumns) {
-        final List<ColumnName> keys = new ArrayList<>(groupByColumns);
-        final List<TableDefinition> prototypes = new ArrayList<>(keys.size() + 1);
-        for (int prefixLength = keys.size(); prefixLength >= 0; --prefixLength) {
-            prototypes.add(makeRollupFormulaPrototype(sourceTable, keys.subList(0, prefixLength)).getDefinition());
+            @NotNull final List<ColumnName> groupByColumns) {
+        final List<TableDefinition> prototypes = new ArrayList<>(groupByColumns.size() + 1);
+        for (int prefixLength = groupByColumns.size(); prefixLength >= 0; --prefixLength) {
+            prototypes.add(
+                    makeRollupFormulaPrototype(sourceTable, groupByColumns.subList(0, prefixLength)).getDefinition());
         }
         return prototypes;
     }

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -12,18 +12,23 @@ import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.filter.Filter;
 import io.deephaven.auth.codegen.impl.HierarchicalTableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.hierarchical.HierarchicalTable;
 import io.deephaven.engine.table.hierarchical.RollupTable;
 import io.deephaven.engine.table.hierarchical.TreeTable;
 import io.deephaven.engine.table.impl.BaseGridAttributes;
+import io.deephaven.engine.table.impl.by.AggregationProcessor;
 import io.deephaven.engine.table.impl.hierarchical.RollupTableImpl;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.select.ConditionFilter;
 import io.deephaven.engine.table.impl.select.SelectColumn;
 import io.deephaven.engine.table.impl.select.WhereFilter;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.qst.type.StringType;
+import io.deephaven.vector.ObjectVector;
 import io.deephaven.extensions.barrage.util.ExportUtil;
 import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
@@ -45,6 +50,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.lang.Object;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -119,6 +125,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                         final Collection<ColumnName> groupByColumns = request.getGroupByColumnsList().stream()
                                 .map(ColumnName::of)
                                 .collect(Collectors.toList());
+                        validateRollupAggregations(request.getAggregationsList(), sourceTable, groupByColumns);
                         final RollupTable result = sourceTable.rollup(
                                 aggregations, includeConstituents, groupByColumns);
 
@@ -134,6 +141,56 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
         Common.validate(request.getResultRollupTableId());
         Common.validate(request.getSourceTableId());
         request.getAggregationsList().forEach(AggregationAdapter::validate);
+    }
+
+    /**
+     * Run the user-supplied expressions in a rollup's aggregations through the {@link ColumnExpressionValidator},
+     * mirroring the validation {@code AggregateGrpcImpl} performs for {@code TableService/Aggregate}. Only the two
+     * rollup aggregation kinds that compile user expressions need checking: {@code AggCountWhere} (filters, compiled
+     * against the source definition) and {@code AggFormula} (a formula selectable, compiled against the grouped
+     * rollup-formula prototype). {@code AggSpecFormula} is unsupported in rollups, so it never reaches compilation.
+     */
+    private void validateRollupAggregations(
+            @NotNull final List<io.deephaven.proto.backplane.grpc.Aggregation> aggregations,
+            @NotNull final Table sourceTable,
+            @NotNull final Collection<ColumnName> groupByColumns) {
+        // Built lazily; only needed (and only well-defined) when a formula aggregation is present.
+        Table formulaPrototype = null;
+        for (final io.deephaven.proto.backplane.grpc.Aggregation agg : aggregations) {
+            if (agg.hasCountWhere()) {
+                columnExpressionValidator.validateSelectFilters(
+                        agg.getCountWhere().getFiltersList().toArray(String[]::new),
+                        sourceTable.getDefinition());
+            } else if (agg.hasFormula()) {
+                final io.deephaven.proto.backplane.grpc.Selectable selectableGrpc = agg.getFormula().getSelectable();
+                if (selectableGrpc.getTypeCase() == io.deephaven.proto.backplane.grpc.Selectable.TypeCase.RAW) {
+                    if (formulaPrototype == null) {
+                        formulaPrototype = makeRollupFormulaPrototype(sourceTable, groupByColumns);
+                    }
+                    final String raw = selectableGrpc.getRaw();
+                    final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(raw));
+                    columnExpressionValidator.validateColumnExpressions(
+                            new SelectColumn[] {selectColumn}, new String[] {raw}, formulaPrototype.getDefinition());
+                }
+            }
+        }
+    }
+
+    /**
+     * Build the definition prototype the engine compiles a rollup formula against, matching
+     * {@code AggregationProcessor}'s rollup formula preparation: the source grouped by the group-by columns (so non-key
+     * columns are exposed as vectors), plus the engine's extra rollup formula columns ({@code __FORMULA_DEPTH__} /
+     * {@code __FORMULA_KEYS__}), which formulas are permitted to reference.
+     */
+    private static Table makeRollupFormulaPrototype(
+            @NotNull final Table sourceTable,
+            @NotNull final Collection<ColumnName> groupByColumns) {
+        final Table grouped = TableTools.newTable(sourceTable.getDefinition()).groupBy(groupByColumns);
+        final List<ColumnDefinition<?>> definitions = new ArrayList<>(grouped.getDefinition().getColumns());
+        definitions.add(ColumnDefinition.ofInt(AggregationProcessor.ROLLUP_FORMULA_DEPTH.name()));
+        definitions.add(ColumnDefinition.of(
+                AggregationProcessor.ROLLUP_FORMULA_KEYS.name(), ObjectVector.type(StringType.of())));
+        return TableTools.newTable(TableDefinition.of(definitions));
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/table/ops/AggregateGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/AggregateGrpcImpl.java
@@ -95,6 +95,7 @@ public final class AggregateGrpcImpl extends GrpcTableOperation<AggregateRequest
                     final Table formulaPrototype = parentPrototype.groupBy(groupByColumns);
                     expressionValidator.validateColumnExpressions(new SelectColumn[] {sc}, new String[] {selectableRaw},
                             formulaPrototype.getDefinition());
+                    break;
                 case TYPE_NOT_SET:
                     break;
                 default:

--- a/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
@@ -298,12 +298,15 @@ public final class UpdateByGrpcImpl extends GrpcTableOperation<UpdateByRequest> 
             final String formulaString = spec.getRollingFormula().getFormula();
             // Substitute the param token with FormulaUtil.replaceFormulaTokens, the literal token-aware replace
             // BaseRollingFormulaOperator uses at runtime, so the validator inspects the string the engine compiles.
-            final SelectColumn[] sc = SelectColumn.from(
-                    Selectable.from(pair.output().name() + "="
-                            + FormulaUtil.replaceFormulaTokens(formulaString,
-                                    spec.getRollingFormula().getParamToken(), inputName)));
+            // Build the expanded output=expression assignment once and pass it as both the parsed Selectable and the
+            // original expression; validators such as MethodNameColumnExpressionValidator re-parse the original and
+            // require the Column=Formula form, so passing the bare formula would break them.
+            final String expandedExpression = pair.output().name() + "="
+                    + FormulaUtil.replaceFormulaTokens(formulaString,
+                            spec.getRollingFormula().getParamToken(), inputName);
+            final SelectColumn[] sc = SelectColumn.from(Selectable.from(expandedExpression));
 
-            expressionValidator.validateColumnExpressions(sc, new String[] {formulaString},
+            expressionValidator.validateColumnExpressions(sc, new String[] {expandedExpression},
                     formulaInputPrototype.getDefinition());
         });
     }

--- a/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
@@ -17,6 +17,7 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.impl.select.FormulaUtil;
 import io.deephaven.engine.table.impl.select.SelectColumn;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.validation.ColumnExpressionValidator;
@@ -295,9 +296,14 @@ public final class UpdateByGrpcImpl extends GrpcTableOperation<UpdateByRequest> 
                     TableTools.newTable(TableDefinition.of(formulaInputDefinition)).groupBy(groupByColumns);
 
             final String formulaString = spec.getRollingFormula().getFormula();
+            // Substitute the param token exactly as the engine does at runtime
+            // (BaseRollingFormulaOperator uses FormulaUtil.replaceFormulaTokens, a literal token-aware replace);
+            // String.replaceAll would treat the user-supplied token as a regex and the replacement as having
+            // group semantics, so the validator could inspect a different string than the engine compiles.
             final SelectColumn[] sc = SelectColumn.from(
                     Selectable.from(pair.output().name() + "="
-                            + formulaString.replaceAll(spec.getRollingFormula().getParamToken(), inputName)));
+                            + FormulaUtil.replaceFormulaTokens(formulaString,
+                                    spec.getRollingFormula().getParamToken(), inputName)));
 
             expressionValidator.validateColumnExpressions(sc, new String[] {formulaString},
                     formulaInputPrototype.getDefinition());

--- a/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
@@ -296,10 +296,8 @@ public final class UpdateByGrpcImpl extends GrpcTableOperation<UpdateByRequest> 
                     TableTools.newTable(TableDefinition.of(formulaInputDefinition)).groupBy(groupByColumns);
 
             final String formulaString = spec.getRollingFormula().getFormula();
-            // Substitute the param token exactly as the engine does at runtime
-            // (BaseRollingFormulaOperator uses FormulaUtil.replaceFormulaTokens, a literal token-aware replace);
-            // String.replaceAll would treat the user-supplied token as a regex and the replacement as having
-            // group semantics, so the validator could inspect a different string than the engine compiles.
+            // Substitute the param token with FormulaUtil.replaceFormulaTokens, the literal token-aware replace
+            // BaseRollingFormulaOperator uses at runtime, so the validator inspects the string the engine compiles.
             final SelectColumn[] sc = SelectColumn.from(
                     Selectable.from(pair.output().name() + "="
                             + FormulaUtil.replaceFormulaTokens(formulaString,

--- a/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
@@ -159,4 +159,32 @@ public class RollupExpressionValidationTest extends GrpcTableOperationTestBase<R
         assertThat(response).isNotNull();
         release(ExportTicketHelper.wrapExportIdInTicket(1));
     }
+
+    /**
+     * A source table may legally already contain a column named {@code __FORMULA_DEPTH__} (a valid identifier). The
+     * validation prototype must replace the same-named source column with the synthetic definition rather than append a
+     * duplicate name (which would make {@code TableDefinition.of} throw and reject every rollup formula), mirroring the
+     * engine's {@code putAll(extraColumns)}.
+     */
+    @Test
+    public void rollupFormulaWhenSourceHasSyntheticColumnNameSucceeds() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100)
+                .view("Key=ii % 2", "__FORMULA_DEPTH__=(int)ii", "Sentinel=(int)ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setFormula(AggregationFormula.newBuilder()
+                                .setSelectable(Selectable.newBuilder()
+                                        .setRaw("FSum = __FORMULA_DEPTH__ == 0 ? max(Sentinel) : 1 + sum(Sentinel)")
+                                        .build())
+                                .build())
+                        .build())
+                .addGroupByColumns("Key")
+                .build();
+
+        final RollupResponse response = rollup(request);
+        assertThat(response).isNotNull();
+        release(ExportTicketHelper.wrapExportIdInTicket(1));
+    }
 }

--- a/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
@@ -124,4 +124,39 @@ public class RollupExpressionValidationTest extends GrpcTableOperationTestBase<R
         assertThat(response).isNotNull();
         release(ExportTicketHelper.wrapExportIdInTicket(1));
     }
+
+    /**
+     * A formula that references the engine's synthetic rollup columns ({@code __FORMULA_DEPTH__} /
+     * {@code __FORMULA_KEYS__}) must validate and build successfully. This guards the validation prototype built by
+     * {@code makeRollupFormulaPrototype}: if it omitted those columns, or gave them the wrong type, the validator would
+     * reject a legitimate request even though the engine compiles it (the engine adds them via
+     * {@code EXTRA_ROLLUP_FORMULA_DEFINITIONS}). The formulas mirror {@code TestRollupTable}.
+     */
+    @Test
+    public void rollupFormulaReferencingSyntheticColumnsSucceeds() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100).view("Key=ii % 2", "Sentinel=(int)ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setFormula(AggregationFormula.newBuilder()
+                                .setSelectable(Selectable.newBuilder()
+                                        .setRaw("FSum = __FORMULA_DEPTH__ == 0 ? max(Sentinel) : 1 + sum(Sentinel)")
+                                        .build())
+                                .build())
+                        .build())
+                .addAggregations(Aggregation.newBuilder()
+                        .setFormula(AggregationFormula.newBuilder()
+                                .setSelectable(Selectable.newBuilder()
+                                        .setRaw("KeyColumns = __FORMULA_KEYS__")
+                                        .build())
+                                .build())
+                        .build())
+                .addGroupByColumns("Key")
+                .build();
+
+        final RollupResponse response = rollup(request);
+        assertThat(response).isNotNull();
+        release(ExportTicketHelper.wrapExportIdInTicket(1));
+    }
 }

--- a/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.hierarchicaltable;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.proto.backplane.grpc.Aggregation;
+import io.deephaven.proto.backplane.grpc.Aggregation.AggregationCountWhere;
+import io.deephaven.proto.backplane.grpc.Aggregation.AggregationFormula;
+import io.deephaven.proto.backplane.grpc.HierarchicalTableServiceGrpc;
+import io.deephaven.proto.backplane.grpc.RollupRequest;
+import io.deephaven.proto.backplane.grpc.RollupResponse;
+import io.deephaven.proto.backplane.grpc.Selectable;
+import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.util.ExportTicketHelper;
+import io.deephaven.server.session.SessionState.ExportObject;
+import io.deephaven.server.table.ops.GrpcTableOperationTestBase;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+/**
+ * Regression test: {@code HierarchicalTableService#rollup} must run user-supplied aggregation expressions through the
+ * {@link io.deephaven.engine.validation.ColumnExpressionValidator}, consistent with {@code TableService#aggregate}
+ * ({@code AggregateGrpcImpl.validateFormulas}) which validates the identical {@code Aggregation} messages.
+ * <p>
+ * Before the fix, the rollup path skipped the validator entirely, so an {@code AggCountWhere} filter containing a
+ * disallowed expression compiled and executed. The chosen expression ({@code Runtime.getRuntime() == null}) is rejected
+ * by the parsed validator but side-effect-free at runtime.
+ */
+public class RollupExpressionValidationTest extends GrpcTableOperationTestBase<RollupRequest> {
+
+    @Override
+    public io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse send(RollupRequest request) {
+        // Not used; rollup returns a RollupResponse rather than an ExportedTableCreationResponse.
+        throw new UnsupportedOperationException();
+    }
+
+    private RollupResponse rollup(RollupRequest request) {
+        final HierarchicalTableServiceGrpc.HierarchicalTableServiceBlockingStub stub =
+                HierarchicalTableServiceGrpc.newBlockingStub(channel().channel());
+        return stub.rollup(request);
+    }
+
+    private Ticket sourceTicket(Table table) {
+        final ExportObject<Table> export = authenticatedSessionState().newServerSideExport(table);
+        return export.getExportId();
+    }
+
+    @Test
+    public void rollupCountWhereRejectsDisallowedExpression() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100).view("Key=ii % 2", "I=ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setCountWhere(AggregationCountWhere.newBuilder()
+                                .setColumnName("Cnt")
+                                // Disallowed by the parsed ColumnExpressionValidator (method invocation on Runtime),
+                                // but harmless if it were to execute.
+                                .addFilters("Runtime.getRuntime() == null")
+                                .build())
+                        .build())
+                .addGroupByColumns("Key")
+                .build();
+
+        // The disallowed expression must be rejected before compilation, mirroring
+        // AggregateGrpcTest#columnsWithFormulaRejectsDisallowedExpression.
+        try {
+            final RollupResponse response = rollup(request);
+            release(ExportTicketHelper.wrapExportIdInTicket(1));
+            failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+        } catch (StatusRuntimeException e) {
+            assertThat(e.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+        }
+    }
+
+    @Test
+    public void rollupFormulaRejectsDisallowedExpression() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100).view("Key=ii % 2", "I=ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setFormula(AggregationFormula.newBuilder()
+                                .setSelectable(Selectable.newBuilder()
+                                        // Disallowed method invocation on Runtime, side-effect-free if it ran.
+                                        .setRaw("Pwned = Runtime.getRuntime().hashCode()")
+                                        .build())
+                                .build())
+                        .build())
+                .addGroupByColumns("Key")
+                .build();
+
+        try {
+            final RollupResponse response = rollup(request);
+            release(ExportTicketHelper.wrapExportIdInTicket(1));
+            failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+        } catch (StatusRuntimeException e) {
+            assertThat(e.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+        }
+    }
+
+    @Test
+    public void rollupCountWhereAcceptsBenignExpression() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100).view("Key=ii % 2", "I=ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setCountWhere(AggregationCountWhere.newBuilder()
+                                .setColumnName("Cnt")
+                                .addFilters("I > 5")
+                                .build())
+                        .build())
+                .addGroupByColumns("Key")
+                .build();
+
+        final RollupResponse response = rollup(request);
+        assertThat(response).isNotNull();
+        release(ExportTicketHelper.wrapExportIdInTicket(1));
+    }
+}

--- a/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/hierarchicaltable/RollupExpressionValidationTest.java
@@ -187,4 +187,34 @@ public class RollupExpressionValidationTest extends GrpcTableOperationTestBase<R
         assertThat(response).isNotNull();
         release(ExportTicketHelper.wrapExportIdInTicket(1));
     }
+
+    /**
+     * A rollup compiles each formula once per level: {@code rollupFromBase} reaggregates by progressively shorter
+     * prefixes of the group-by columns, and the validator checks the formula against every such prefix (base down to
+     * the empty-key root). This multi-key case exercises three prototype levels ({@code [Key1, Key2]}, {@code [Key1]},
+     * {@code []}); a formula over a non-key column plus the synthetic depth column is valid at all of them and must not
+     * be over-rejected by the per-level loop.
+     */
+    @Test
+    public void rollupFormulaValidatedAtEveryLevelSucceeds() {
+        final Ticket source = sourceTicket(TableTools.emptyTable(100)
+                .view("Key1=(ii % 2 == 0) ? `a` : `b`", "Key2=(ii % 3 == 0) ? `x` : `y`", "Sentinel=(int)ii"));
+        final RollupRequest request = RollupRequest.newBuilder()
+                .setResultRollupTableId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceTableId(source)
+                .addAggregations(Aggregation.newBuilder()
+                        .setFormula(AggregationFormula.newBuilder()
+                                .setSelectable(Selectable.newBuilder()
+                                        .setRaw("FSum = __FORMULA_DEPTH__ == 0 ? max(Sentinel) : 1 + sum(Sentinel)")
+                                        .build())
+                                .build())
+                        .build())
+                .addGroupByColumns("Key1")
+                .addGroupByColumns("Key2")
+                .build();
+
+        final RollupResponse response = rollup(request);
+        assertThat(response).isNotNull();
+        release(ExportTicketHelper.wrapExportIdInTicket(1));
+    }
 }

--- a/server/src/test/java/io/deephaven/server/table/ops/UpdateByRollingFormulaValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/UpdateByRollingFormulaValidationTest.java
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.table.ops;
+
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
+import io.deephaven.proto.backplane.grpc.TableReference;
+import io.deephaven.proto.backplane.grpc.UpdateByRequest;
+import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation;
+import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn;
+import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn.UpdateBySpec;
+import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn.UpdateBySpec.UpdateByRollingFormula;
+import io.deephaven.proto.backplane.grpc.UpdateByWindowScale;
+import io.deephaven.proto.backplane.grpc.UpdateByWindowScale.UpdateByWindowTicks;
+import io.deephaven.proto.util.ExportTicketHelper;
+import io.grpc.Status.Code;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Server-level regression tests for the {@code UpdateByGrpcImpl} rolling-formula validation, specifically the
+ * param-token substitution used to build the string the
+ * {@link io.deephaven.engine.validation.ColumnExpressionValidator} inspects. The validator must substitute the token
+ * exactly as the engine's {@code BaseRollingFormulaOperator} does (via {@code FormulaUtil.replaceFormulaTokens} — a
+ * literal, token-aware replace), NOT with {@code String.replaceAll}, which would treat the user-supplied token as a
+ * regex.
+ */
+public class UpdateByRollingFormulaValidationTest extends GrpcTableOperationTestBase<UpdateByRequest> {
+
+    @Override
+    public ExportedTableCreationResponse send(UpdateByRequest request) {
+        return channel().tableBlocking().updateBy(request);
+    }
+
+    private static UpdateByWindowScale ticksScale(double ticks) {
+        return UpdateByWindowScale.newBuilder()
+                .setTicks(UpdateByWindowTicks.newBuilder().setTicks(ticks).build())
+                .build();
+    }
+
+    private UpdateByRequest rollingFormulaRequest(String formula, String paramToken, String matchPair) {
+        final TableReference ref = ref(TableTools.emptyTable(100).view("Key=ii % 2", "Value=(int)ii"));
+        final UpdateByColumn.Builder column = UpdateByColumn.newBuilder()
+                .setSpec(UpdateBySpec.newBuilder()
+                        .setRollingFormula(UpdateByRollingFormula.newBuilder()
+                                .setReverseWindowScale(ticksScale(5))
+                                .setForwardWindowScale(ticksScale(0))
+                                .setFormula(formula)
+                                .setParamToken(paramToken)
+                                .build())
+                        .build());
+        if (matchPair != null) {
+            column.addMatchPairs(matchPair);
+        }
+        return UpdateByRequest.newBuilder()
+                .setResultId(ExportTicketHelper.wrapExportIdInTicket(1))
+                .setSourceId(ref)
+                .addOperations(UpdateByOperation.newBuilder().setColumn(column.build()).build())
+                .addGroupByColumns("Key")
+                .build();
+    }
+
+    /**
+     * A param token consisting of regex metacharacters ({@code .*}) that does not appear as a literal token in the
+     * formula. With the old {@code String.replaceAll} substitution, {@code .*} matches (and replaces) the entire
+     * formula, so the validator would inspect a benign column reference and let the disallowed {@code Runtime}
+     * invocation through. With token-aware literal substitution, the token does not match, so the validator inspects
+     * the real formula and rejects it.
+     */
+    @Test
+    public void rollingFormulaRegexParamTokenDoesNotHideDisallowedExpression() {
+        final UpdateByRequest request = rollingFormulaRequest(
+                "Runtime.getRuntime().exec(\"pwned\") == null", ".*", "Out=Value");
+        // The validator runs at export time, so its rejection is sanitized to "Details Logged w/ID"; a synchronous
+        // request error (e.g. a bad window scale) would surface with its raw message instead, so this also confirms
+        // the failure is the deferred ColumnExpressionValidator rather than earlier request validation.
+        assertError(request, Code.INVALID_ARGUMENT, "Details Logged w/ID");
+    }
+
+    /**
+     * A benign rolling formula whose param token is a substring of an unrelated identifier in the formula
+     * ({@code sum}); a naive {@code replaceAll} would corrupt {@code sum} into {@code s<input>m}, breaking validation
+     * of an otherwise valid request. Token-aware substitution only replaces the standalone token, so this validates and
+     * builds successfully.
+     */
+    @Test
+    public void rollingFormulaTokenInsideIdentifierStillSucceeds() {
+        final UpdateByRequest request = rollingFormulaRequest("sum(u)", "u", "Out=Value");
+        final ExportedTableCreationResponse response = send(request);
+        assertThat(response.getSuccess()).isTrue();
+        release(response);
+    }
+}

--- a/server/src/test/java/io/deephaven/server/table/ops/UpdateByRollingFormulaValidationTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/UpdateByRollingFormulaValidationTest.java
@@ -63,16 +63,18 @@ public class UpdateByRollingFormulaValidationTest extends GrpcTableOperationTest
     }
 
     /**
-     * A param token consisting of regex metacharacters ({@code .*}) that does not appear as a literal token in the
-     * formula. With the old {@code String.replaceAll} substitution, {@code .*} matches (and replaces) the entire
-     * formula, so the validator would inspect a benign column reference and let the disallowed {@code Runtime}
-     * invocation through. With token-aware literal substitution, the token does not match, so the validator inspects
-     * the real formula and rejects it.
+     * A param token consisting of regex metacharacters ({@code .+}) that does not appear as a literal token in the
+     * formula, paired with a forbidden-but-side-effect-free method ({@code Runtime.getRuntime()}) that runs
+     * successfully if compiled. With the old {@code String.replaceAll} substitution, {@code .+} matches (and replaces)
+     * the entire formula, so the validator inspects a benign column reference ({@code Out=Value}) and admits the
+     * request; the engine then compiles and runs the untouched forbidden formula — a validation bypass. With
+     * token-aware literal substitution, the token does not match, the validator inspects the real formula, and rejects
+     * it. So this fails (the request succeeds) on the unfixed path and passes only once the bypass is closed.
      */
     @Test
     public void rollingFormulaRegexParamTokenDoesNotHideDisallowedExpression() {
         final UpdateByRequest request = rollingFormulaRequest(
-                "Runtime.getRuntime().exec(\"pwned\") == null", ".*", "Out=Value");
+                "Runtime.getRuntime().hashCode()", ".+", "Out=Value");
         // The validator runs at export time, so its rejection is sanitized to "Details Logged w/ID"; a synchronous
         // request error (e.g. a bad window scale) would surface with its raw message instead, so this also confirms
         // the failure is the deferred ColumnExpressionValidator rather than earlier request validation.

--- a/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
+++ b/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
@@ -8,6 +8,7 @@ import io.deephaven.api.filter.Filter;
 import io.deephaven.api.filter.FilterComparison;
 import io.deephaven.api.literal.Literal;
 import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
+import io.deephaven.base.verify.AssertionFailure;
 import io.deephaven.client.impl.FilterAdapter;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.context.ExecutionContext;
@@ -634,6 +635,26 @@ public class TestColumnExpressionValidator {
                 ise.getMessage().startsWith("User expressions are not permitted to instantiate "));
         Assert.assertTrue("Actual: " + ise.getMessage(),
                 ise.getMessage().endsWith("String"));
+    }
+
+    @Test
+    public void testMethodNameRequiresExpandedAssignmentAsOriginalExpression() {
+        // UpdateByGrpcImpl validates a rolling formula by expanding the param token into an "output=expression"
+        // assignment. MethodNameColumnExpressionValidator re-parses the original-expression argument and requires that
+        // Column=Formula form (see validateSelectColumnHelper), so the original expression passed alongside the
+        // SelectColumn must be the expanded assignment, not the bare formula body.
+        final ColumnExpressionValidator validator = new MethodNameColumnExpressionValidator();
+        final Table input = TableTools.emptyTable(1).update("Value=1");
+
+        final String expanded = "Out=Value + 1";
+        final SelectColumn[] sc = SelectColumnFactory.getExpressions(expanded);
+
+        // Passing the bare formula (no '=') fails the Column=Formula requirement.
+        Assert.assertThrows(AssertionFailure.class,
+                () -> validator.validateColumnExpressions(sc, new String[] {"Value + 1"}, input.getDefinition()));
+
+        // Passing the expanded assignment validates cleanly, as UpdateByGrpcImpl now does.
+        validator.validateColumnExpressions(sc, new String[] {expanded}, input.getDefinition());
     }
 
     @Test


### PR DESCRIPTION
HierarchicalTableService/Rollup compiled user-supplied aggregation expressions without running them through ColumnExpressionValidator, unlike TableService/Aggregate and /AggregateAll which validate the identical Aggregation messages. AggCountWhere filters and AggFormula selectables were compiled unchecked at the rollup base level, bypassing the method allow-list.

- rollup: validate AggCountWhere filters against the source definition and AggFormula selectables against a grouped rollup-formula prototype (including the engine's __FORMULA_DEPTH__/__FORMULA_KEYS__ columns), mirroring AggregateGrpcImpl.
- UpdateByGrpcImpl: substitute the rolling-formula param token with FormulaUtil.replaceFormulaTokens (literal, token-aware) instead of String.replaceAll (regex), so the validator inspects the same string the engine compiles.
- AggregateGrpcImpl: add the missing break after the RAW formula case.

Covered by RollupExpressionValidationTest.