### PR TITLE
perf: DH-23616: Eliminate reader lock contention in TestSource column sources

### DIFF
--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ByteTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ByteTestSource.java
@@ -119,8 +119,7 @@ public class ByteTestSource extends AbstractColumnSource<Byte>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2ByteOpenHashMap newData = new Long2ByteOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2ByteOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ByteTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ByteTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The ByteTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to byte values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class ByteTestSource extends AbstractColumnSource<Byte>
         implements MutableColumnSourceGetDefaults.ForByte, TestColumnSource<Byte> {
 
     private long lastAdditionTime;
-    protected final Long2ByteOpenHashMap data = new Long2ByteOpenHashMap();
-    protected Long2ByteOpenHashMap prevData;
+    protected volatile Long2ByteOpenHashMap data = new Long2ByteOpenHashMap();
+    protected volatile Long2ByteOpenHashMap prevData;
 
     private final UpdateCommitter<ByteTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, ByteTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class ByteTestSource extends AbstractColumnSource<Byte>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2ByteOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2ByteOpenHashMap newData = new Long2ByteOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class ByteTestSource extends AbstractColumnSource<Byte>
     // endregion boxed get
 
     @Override
-    public synchronized byte getByte(long index) {
+    public byte getByte(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_BYTE;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2ByteOpenHashMap data = this.data;
         final byte retVal = data.get(index);
         if (retVal == QueryConstants.NULL_BYTE && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class ByteTestSource extends AbstractColumnSource<Byte>
     // endregion boxed getPrev
 
     @Override
-    public synchronized byte getPrevByte(long index) {
+    public byte getPrevByte(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_BYTE;
         }
 
-        if (prevData == null) {
-            return getByte(index);
-        }
-
+        final Long2ByteOpenHashMap prevData = this.prevData;
         final byte retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_BYTE && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class ByteTestSource extends AbstractColumnSource<Byte>
     }
 
     public static void flushPrevious(ByteTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/CharTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/CharTestSource.java
@@ -27,16 +27,19 @@ import java.util.function.LongConsumer;
  * The CharTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to char values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class CharTestSource extends AbstractColumnSource<Character>
         implements MutableColumnSourceGetDefaults.ForChar, TestColumnSource<Character> {
 
     private long lastAdditionTime;
-    protected final Long2CharOpenHashMap data = new Long2CharOpenHashMap();
-    protected Long2CharOpenHashMap prevData;
+    protected volatile Long2CharOpenHashMap data = new Long2CharOpenHashMap();
+    protected volatile Long2CharOpenHashMap prevData;
 
     private final UpdateCommitter<CharTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, CharTestSource::flushPrevious);
@@ -112,8 +115,10 @@ public class CharTestSource extends AbstractColumnSource<Character>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2CharOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2CharOpenHashMap newData = new Long2CharOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -145,13 +150,14 @@ public class CharTestSource extends AbstractColumnSource<Character>
     // endregion boxed get
 
     @Override
-    public synchronized char getChar(long index) {
+    public char getChar(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_CHAR;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2CharOpenHashMap data = this.data;
         final char retVal = data.get(index);
         if (retVal == QueryConstants.NULL_CHAR && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -172,15 +178,12 @@ public class CharTestSource extends AbstractColumnSource<Character>
     // endregion boxed getPrev
 
     @Override
-    public synchronized char getPrevChar(long index) {
+    public char getPrevChar(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_CHAR;
         }
 
-        if (prevData == null) {
-            return getChar(index);
-        }
-
+        final Long2CharOpenHashMap prevData = this.prevData;
         final char retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_CHAR && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -189,7 +192,7 @@ public class CharTestSource extends AbstractColumnSource<Character>
     }
 
     public static void flushPrevious(CharTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/CharTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/CharTestSource.java
@@ -115,8 +115,7 @@ public class CharTestSource extends AbstractColumnSource<Character>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2CharOpenHashMap newData = new Long2CharOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2CharOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/DoubleTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/DoubleTestSource.java
@@ -119,8 +119,7 @@ public class DoubleTestSource extends AbstractColumnSource<Double>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2DoubleOpenHashMap newData = new Long2DoubleOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2DoubleOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/DoubleTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/DoubleTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The DoubleTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to double values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class DoubleTestSource extends AbstractColumnSource<Double>
         implements MutableColumnSourceGetDefaults.ForDouble, TestColumnSource<Double> {
 
     private long lastAdditionTime;
-    protected final Long2DoubleOpenHashMap data = new Long2DoubleOpenHashMap();
-    protected Long2DoubleOpenHashMap prevData;
+    protected volatile Long2DoubleOpenHashMap data = new Long2DoubleOpenHashMap();
+    protected volatile Long2DoubleOpenHashMap prevData;
 
     private final UpdateCommitter<DoubleTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, DoubleTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class DoubleTestSource extends AbstractColumnSource<Double>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2DoubleOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2DoubleOpenHashMap newData = new Long2DoubleOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class DoubleTestSource extends AbstractColumnSource<Double>
     // endregion boxed get
 
     @Override
-    public synchronized double getDouble(long index) {
+    public double getDouble(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_DOUBLE;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2DoubleOpenHashMap data = this.data;
         final double retVal = data.get(index);
         if (retVal == QueryConstants.NULL_DOUBLE && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class DoubleTestSource extends AbstractColumnSource<Double>
     // endregion boxed getPrev
 
     @Override
-    public synchronized double getPrevDouble(long index) {
+    public double getPrevDouble(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_DOUBLE;
         }
 
-        if (prevData == null) {
-            return getDouble(index);
-        }
-
+        final Long2DoubleOpenHashMap prevData = this.prevData;
         final double retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_DOUBLE && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class DoubleTestSource extends AbstractColumnSource<Double>
     }
 
     public static void flushPrevious(DoubleTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/FloatTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/FloatTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The FloatTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to float values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class FloatTestSource extends AbstractColumnSource<Float>
         implements MutableColumnSourceGetDefaults.ForFloat, TestColumnSource<Float> {
 
     private long lastAdditionTime;
-    protected final Long2FloatOpenHashMap data = new Long2FloatOpenHashMap();
-    protected Long2FloatOpenHashMap prevData;
+    protected volatile Long2FloatOpenHashMap data = new Long2FloatOpenHashMap();
+    protected volatile Long2FloatOpenHashMap prevData;
 
     private final UpdateCommitter<FloatTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, FloatTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class FloatTestSource extends AbstractColumnSource<Float>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2FloatOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2FloatOpenHashMap newData = new Long2FloatOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class FloatTestSource extends AbstractColumnSource<Float>
     // endregion boxed get
 
     @Override
-    public synchronized float getFloat(long index) {
+    public float getFloat(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_FLOAT;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2FloatOpenHashMap data = this.data;
         final float retVal = data.get(index);
         if (retVal == QueryConstants.NULL_FLOAT && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class FloatTestSource extends AbstractColumnSource<Float>
     // endregion boxed getPrev
 
     @Override
-    public synchronized float getPrevFloat(long index) {
+    public float getPrevFloat(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_FLOAT;
         }
 
-        if (prevData == null) {
-            return getFloat(index);
-        }
-
+        final Long2FloatOpenHashMap prevData = this.prevData;
         final float retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_FLOAT && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class FloatTestSource extends AbstractColumnSource<Float>
     }
 
     public static void flushPrevious(FloatTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/FloatTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/FloatTestSource.java
@@ -119,8 +119,7 @@ public class FloatTestSource extends AbstractColumnSource<Float>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2FloatOpenHashMap newData = new Long2FloatOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2FloatOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/IntTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/IntTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The IntTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to int values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class IntTestSource extends AbstractColumnSource<Integer>
         implements MutableColumnSourceGetDefaults.ForInt, TestColumnSource<Integer> {
 
     private long lastAdditionTime;
-    protected final Long2IntOpenHashMap data = new Long2IntOpenHashMap();
-    protected Long2IntOpenHashMap prevData;
+    protected volatile Long2IntOpenHashMap data = new Long2IntOpenHashMap();
+    protected volatile Long2IntOpenHashMap prevData;
 
     private final UpdateCommitter<IntTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, IntTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class IntTestSource extends AbstractColumnSource<Integer>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2IntOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2IntOpenHashMap newData = new Long2IntOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class IntTestSource extends AbstractColumnSource<Integer>
     // endregion boxed get
 
     @Override
-    public synchronized int getInt(long index) {
+    public int getInt(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_INT;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2IntOpenHashMap data = this.data;
         final int retVal = data.get(index);
         if (retVal == QueryConstants.NULL_INT && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class IntTestSource extends AbstractColumnSource<Integer>
     // endregion boxed getPrev
 
     @Override
-    public synchronized int getPrevInt(long index) {
+    public int getPrevInt(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_INT;
         }
 
-        if (prevData == null) {
-            return getInt(index);
-        }
-
+        final Long2IntOpenHashMap prevData = this.prevData;
         final int retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_INT && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class IntTestSource extends AbstractColumnSource<Integer>
     }
 
     public static void flushPrevious(IntTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/IntTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/IntTestSource.java
@@ -119,8 +119,7 @@ public class IntTestSource extends AbstractColumnSource<Integer>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2IntOpenHashMap newData = new Long2IntOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2IntOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/LongTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/LongTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The LongTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to long values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class LongTestSource extends AbstractColumnSource<Long>
         implements MutableColumnSourceGetDefaults.ForLong, TestColumnSource<Long> {
 
     private long lastAdditionTime;
-    protected final Long2LongOpenHashMap data = new Long2LongOpenHashMap();
-    protected Long2LongOpenHashMap prevData;
+    protected volatile Long2LongOpenHashMap data = new Long2LongOpenHashMap();
+    protected volatile Long2LongOpenHashMap prevData;
 
     private final UpdateCommitter<LongTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, LongTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class LongTestSource extends AbstractColumnSource<Long>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2LongOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2LongOpenHashMap newData = new Long2LongOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class LongTestSource extends AbstractColumnSource<Long>
     // endregion boxed get
 
     @Override
-    public synchronized long getLong(long index) {
+    public long getLong(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_LONG;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2LongOpenHashMap data = this.data;
         final long retVal = data.get(index);
         if (retVal == QueryConstants.NULL_LONG && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class LongTestSource extends AbstractColumnSource<Long>
     // endregion boxed getPrev
 
     @Override
-    public synchronized long getPrevLong(long index) {
+    public long getPrevLong(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_LONG;
         }
 
-        if (prevData == null) {
-            return getLong(index);
-        }
-
+        final Long2LongOpenHashMap prevData = this.prevData;
         final long retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_LONG && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class LongTestSource extends AbstractColumnSource<Long>
     }
 
     public static void flushPrevious(LongTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/LongTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/LongTestSource.java
@@ -119,8 +119,7 @@ public class LongTestSource extends AbstractColumnSource<Long>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2LongOpenHashMap newData = new Long2LongOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2LongOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ObjectTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ObjectTestSource.java
@@ -29,16 +29,19 @@ import java.util.function.LongConsumer;
  * The ObjectTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to Object values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class ObjectTestSource<T> extends AbstractColumnSource<T>
         implements MutableColumnSourceGetDefaults.ForObject<T>, TestColumnSource<T> {
 
     private long lastAdditionTime;
-    protected final Long2ObjectOpenHashMap<T> data = new Long2ObjectOpenHashMap<T>();
-    protected Long2ObjectOpenHashMap<T> prevData;
+    protected volatile Long2ObjectOpenHashMap<T> data = new Long2ObjectOpenHashMap<T>();
+    protected volatile Long2ObjectOpenHashMap<T> prevData;
 
     private final UpdateCommitter<ObjectTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, ObjectTestSource::flushPrevious);
@@ -99,8 +102,10 @@ public class ObjectTestSource<T> extends AbstractColumnSource<T>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2ObjectOpenHashMap<T>(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2ObjectOpenHashMap<T> newData = new Long2ObjectOpenHashMap<T>(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -128,13 +133,14 @@ public class ObjectTestSource<T> extends AbstractColumnSource<T>
     // endregion boxed get
 
     @Override
-    public synchronized T get(long index) {
+    public T get(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return null;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2ObjectOpenHashMap<T> data = this.data;
         final T retVal = data.get(index);
         if (retVal == null && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -151,15 +157,12 @@ public class ObjectTestSource<T> extends AbstractColumnSource<T>
     // endregion boxed getPrev
 
     @Override
-    public synchronized T getPrev(long index) {
+    public T getPrev(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return null;
         }
 
-        if (prevData == null) {
-            return get(index);
-        }
-
+        final Long2ObjectOpenHashMap<T> prevData = this.prevData;
         final T retVal = prevData.get(index);
         if (retVal == null && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -168,7 +171,7 @@ public class ObjectTestSource<T> extends AbstractColumnSource<T>
     }
 
     public static void flushPrevious(ObjectTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ObjectTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ObjectTestSource.java
@@ -102,8 +102,7 @@ public class ObjectTestSource<T> extends AbstractColumnSource<T>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2ObjectOpenHashMap<T> newData = new Long2ObjectOpenHashMap<T>(this.data);
-        setDefaultReturnValue(newData);
+        final Long2ObjectOpenHashMap<T> newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ShortTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ShortTestSource.java
@@ -31,16 +31,19 @@ import java.util.function.LongConsumer;
  * The ShortTestSource is a ColumnSource used only for testing; not in live code.
  * <p>
  * It uses a fastutil open addressed hash map from long RowSet keys to short values. Previous data is stored in a
- * completely separate map, which is copied from the primary map on the first change in a given cycle. If an
- * uninitialized key is accessed; then an IllegalStateException is thrown. The previous value map is discarded in an
- * {@link UpdateCommitter} using a {@link TerminalNotification} after the live table monitor cycle is complete.
+ * completely separate map: on the first change in a given cycle, the current map is copied into a fresh map that
+ * receives the cycle's mutations, and the prior map is retained as the previous values. A map is never mutated once it
+ * has been retained as previous, so readers access the volatile map references without locking while mutators
+ * synchronize on this source. If an uninitialized key is accessed; then an IllegalStateException is thrown. The
+ * previous value map reference is reset to the current map in an {@link UpdateCommitter} using a
+ * {@link TerminalNotification} after the live table monitor cycle is complete.
  */
 public class ShortTestSource extends AbstractColumnSource<Short>
         implements MutableColumnSourceGetDefaults.ForShort, TestColumnSource<Short> {
 
     private long lastAdditionTime;
-    protected final Long2ShortOpenHashMap data = new Long2ShortOpenHashMap();
-    protected Long2ShortOpenHashMap prevData;
+    protected volatile Long2ShortOpenHashMap data = new Long2ShortOpenHashMap();
+    protected volatile Long2ShortOpenHashMap prevData;
 
     private final UpdateCommitter<ShortTestSource> prevFlusher =
             new UpdateCommitter<>(this, updateGraph, ShortTestSource::flushPrevious);
@@ -116,8 +119,10 @@ public class ShortTestSource extends AbstractColumnSource<Short>
             return;
         }
         prevFlusher.maybeActivate();
-        prevData = new Long2ShortOpenHashMap(this.data);
-        setDefaultReturnValue(prevData);
+        final Long2ShortOpenHashMap newData = new Long2ShortOpenHashMap(this.data);
+        setDefaultReturnValue(newData);
+        prevData = data;
+        data = newData;
         lastAdditionTime = currentStep;
     }
 
@@ -149,13 +154,14 @@ public class ShortTestSource extends AbstractColumnSource<Short>
     // endregion boxed get
 
     @Override
-    public synchronized short getShort(long index) {
+    public short getShort(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_SHORT;
         }
         // If a test asks for a non-existent positive index something is wrong.
         // We have to accept negative values, because e.g. a join may find no matching right key, in which case it
         // has an empty redirection index entry that just gets passed through to the inner column source as -1.
+        final Long2ShortOpenHashMap data = this.data;
         final short retVal = data.get(index);
         if (retVal == QueryConstants.NULL_SHORT && !data.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent key: " + index);
@@ -176,15 +182,12 @@ public class ShortTestSource extends AbstractColumnSource<Short>
     // endregion boxed getPrev
 
     @Override
-    public synchronized short getPrevShort(long index) {
+    public short getPrevShort(long index) {
         if (index == RowSet.NULL_ROW_KEY) {
             return QueryConstants.NULL_SHORT;
         }
 
-        if (prevData == null) {
-            return getShort(index);
-        }
-
+        final Long2ShortOpenHashMap prevData = this.prevData;
         final short retVal = prevData.get(index);
         if (retVal == QueryConstants.NULL_SHORT && !prevData.containsKey(index)) {
             throw new IllegalStateException("Asking for a non-existent previous key: " + index);
@@ -193,7 +196,7 @@ public class ShortTestSource extends AbstractColumnSource<Short>
     }
 
     public static void flushPrevious(ShortTestSource source) {
-        source.prevData = null;
+        source.prevData = source.data;
     }
 
     @Override

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ShortTestSource.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/sources/ShortTestSource.java
@@ -119,8 +119,7 @@ public class ShortTestSource extends AbstractColumnSource<Short>
             return;
         }
         prevFlusher.maybeActivate();
-        final Long2ShortOpenHashMap newData = new Long2ShortOpenHashMap(this.data);
-        setDefaultReturnValue(newData);
+        final Long2ShortOpenHashMap newData = this.data.clone();
         prevData = data;
         data = newData;
         lastAdditionTime = currentStep;


### PR DESCRIPTION
The synchronized per-element getters on the testutil TestSource classes
were heavily contended when concurrent update-graph threads (sort
comparators, chunk fillers, validators) read the same source; monitor
spinning accounted for roughly a third of QueryTableAggregationTest's
CPU time.

On the first change in a cycle, the current map is now copied into a
fresh map that receives the cycle's mutations, and the prior map is
retained as the previous values. A map is never mutated once retained
as previous, so get and getPrev read the volatile map references
without locking while mutators still synchronize on the source. The
allocation cost is unchanged: one map copy per changed cycle.
