### PR TITLE
fix: DH-23579: Keep the packed ArrayContainer shared flag in the short[] itself

### DIFF
--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
@@ -25,10 +25,12 @@ public class ArrayContainer extends Container {
     // objects to 8 bytes boundaries.
     // So an array of 4 elements uses: 12 + 2*4 + 4 padding = 24 bytes = 3*8 bytes.
     // The 4 bytes of padding are wasted and can be used for another 2 short elements.
-    private static final int DEFAULT_INIT_SIZE = 6;
+    // The default initial capacity of 5 values plus the reserved slot is 6 shorts, which fills those 24 bytes.
+    private static final int DEFAULT_INIT_CAPACITY = 5;
 
-    // containers with DEFAULT_MAX_SZE or less integers should be ArrayContainers
-    static final int DEFAULT_MAX_SIZE = 4096 - 6; // 12 bytes of object overhead is 6 shorts.
+    // containers with DEFAULT_MAX_SIZE or less integers should be ArrayContainers; at that cardinality the content
+    // array (12 bytes of array header, the values, and the reserved slot) is exactly 8192 bytes, the size of a bitmap.
+    static final int DEFAULT_MAX_SIZE = 4096 - 6 - 1;
 
     public static final int SWITCH_CONTAINER_CARDINALITY_THRESHOLD = DEFAULT_MAX_SIZE - DEFAULT_MAX_SIZE / 16;
 
@@ -38,25 +40,95 @@ public class ArrayContainer extends Container {
 
     protected int cardinality = 0;
 
+    /**
+     * The values, in increasing unsigned order, at indices {@code [0, cardinality)}. The last element is reserved: it
+     * never holds a value, so a container's capacity is {@code content.length - 1}, and it is where the array's
+     * {@link #isContentShared(short[]) shared flag} lives; see {@link #getContent()}.
+     */
     protected short[] content;
 
-    protected boolean shared = false;
+    /**
+     * Bit set in the reserved last element of a content array once the array is shared, copy-on-write, by more than one
+     * owner. The remaining bits of the slot are unused.
+     */
+    private static final short CONTENT_SHARED_FLAG = 1;
 
+    /**
+     * The backing array of this container, which the caller may store in place of the container itself, as
+     * {@code io.deephaven.engine.rowset.impl.rsp.RspArray} does to avoid an object per small container. The array
+     * stands on its own: its values occupy indices {@code [0, cardinality)}, and its last element is reserved for the
+     * shared flag rather than a value, so a holder of the bare array can {@link #markContentShared(short[]) mark} it
+     * shared or {@link #isContentShared(short[]) ask} whether it is, without a container object to hold the flag.
+     *
+     * <p>
+     * The flag lives in the array, rather than in a word beside it, so that marking it is a write to the array itself
+     * and to nothing else: whoever holds a reference to the array can only ever affect that array by marking it, never
+     * a span the array's owner has since replaced it with. The flag is only ever set, never cleared; a shared array is
+     * never again written in place by anyone, so a stale set flag costs at most one copy.
+     *
+     * @return this container's backing array
+     */
     public short[] getContent() {
         return content;
     }
 
-    protected ArrayContainer(final short[] content, final int cardinality, final boolean shared) {
+    /**
+     * Whether the content array is shared, copy-on-write, by more than one owner; see {@link #getContent()}.
+     *
+     * @param content a content array, as returned by {@link #getContent()}
+     * @return whether the array is marked shared
+     */
+    public static boolean isContentShared(final short[] content) {
+        return (content[content.length - 1] & CONTENT_SHARED_FLAG) != 0;
+    }
+
+    /**
+     * Mark the content array shared, copy-on-write, by more than one owner; see {@link #getContent()}. Idempotent, and
+     * safe to call concurrently with another marking of the same array and with the owner's in-place writes of values,
+     * which never touch the reserved slot.
+     *
+     * @param content a content array, as returned by {@link #getContent()}
+     */
+    public static void markContentShared(final short[] content) {
+        content[content.length - 1] |= CONTENT_SHARED_FLAG;
+    }
+
+    /**
+     * The length of a content array able to hold {@code capacity} values: the values, the reserved slot, and whatever
+     * padding brings the array up to the next 8 byte boundary the allocator would round it to anyway.
+     */
+    private static int contentLength(final int capacity) {
+        return shortArraySizeRounding(capacity + 1);
+    }
+
+    /** A fresh, unshared content array able to hold {@code capacity} values. */
+    private static short[] newContent(final int capacity) {
+        return new short[contentLength(capacity)];
+    }
+
+    /** The number of values the content array can hold. */
+    int capacity() {
+        return content.length - 1;
+    }
+
+    /**
+     * Wrap an existing array without checks, for {@link #makeByWrapping} and for subclasses that install their content
+     * later.
+     */
+    protected ArrayContainer(final short[] content, final int cardinality) {
+        if (content != null && cardinality >= content.length) {
+            throw new IllegalArgumentException(
+                    "cardinality=" + cardinality + " leaves no reserved slot in an array of length " + content.length);
+        }
         this.content = content;
         this.cardinality = cardinality;
-        this.shared = shared;
     }
 
     /**
      * Create an array container with default capacity
      */
     public ArrayContainer() {
-        this(DEFAULT_INIT_SIZE);
+        this(DEFAULT_INIT_CAPACITY);
     }
 
     /**
@@ -65,7 +137,7 @@ public class ArrayContainer extends Container {
      * @param capacity The capacity of the container
      */
     public ArrayContainer(final int capacity) {
-        content = new short[shortArraySizeRounding(capacity)];
+        content = newContent(capacity);
     }
 
     /**
@@ -77,7 +149,7 @@ public class ArrayContainer extends Container {
      */
     ArrayContainer(final int firstOfRun, final int lastOfRun) {
         final int valuesInRange = lastOfRun - firstOfRun;
-        content = new short[shortArraySizeRounding(valuesInRange)];
+        content = newContent(valuesInRange);
         for (int i = 0; i < valuesInRange; ++i) {
             content[i] = (short) (firstOfRun + i);
         }
@@ -86,7 +158,7 @@ public class ArrayContainer extends Container {
 
     private ArrayContainer(final ArrayContainer src, final int startRank, final int endRank) {
         cardinality = endRank - startRank;
-        content = new short[shortArraySizeRounding(cardinality)];
+        content = newContent(cardinality);
         System.arraycopy(src.content, startRank, content, 0, cardinality);
     }
 
@@ -100,19 +172,14 @@ public class ArrayContainer extends Container {
      */
     private ArrayContainer(final int newCapacity, final short[] arr, final int offset, final int sz) {
         cardinality = sz;
-        final short[] cs = new short[shortArraySizeRounding(newCapacity)];
+        final short[] cs = newContent(newCapacity);
         System.arraycopy(arr, offset, cs, 0, sz);
         content = cs;
     }
 
-    public ArrayContainer(final short[] arr, final int sz) {
-        cardinality = sz;
-        content = arr;
-    }
-
     // Caller should ensure arguments provided in increasing unsigned order.
     ArrayContainer(final short v0, final short v1, final short v2) {
-        content = new short[DEFAULT_INIT_SIZE];
+        content = newContent(DEFAULT_INIT_CAPACITY);
         content[0] = v0;
         content[1] = v1;
         content[2] = v2;
@@ -121,14 +188,14 @@ public class ArrayContainer extends Container {
 
     // Caller should ensure arguments provided in increasing unsigned order.
     ArrayContainer(final short v0, final short v1) {
-        content = new short[DEFAULT_INIT_SIZE];
+        content = newContent(DEFAULT_INIT_CAPACITY);
         content[0] = v0;
         content[1] = v1;
         cardinality = 2;
     }
 
     ArrayContainer(final short v) {
-        content = new short[DEFAULT_INIT_SIZE];
+        content = newContent(DEFAULT_INIT_CAPACITY);
         content[0] = v;
         cardinality = 1;
     }
@@ -153,17 +220,22 @@ public class ArrayContainer extends Container {
     /**
      * Construct a new ArrayContainer using the provided array. The container takes ownership of the array.
      *
-     * @param arr array with values in increasing unsigned short order. The container takes ownership of this array.
-     * @param sz number of elements in arr.
+     * @param arr array with values in increasing unsigned short order, with at least one element beyond them for the
+     *        container's reserved last slot; whether that slot is marked shared is taken as is. The container takes
+     *        ownership of this array.
+     * @param sz number of values in arr.
      */
-    @SuppressWarnings("unused")
     public static ArrayContainer makeByWrapping(final short[] arr, final int sz) {
         return new ArrayContainer(arr, sz);
     }
 
-    public ArrayContainer(final short[] newContent) {
-        cardinality = newContent.length;
-        content = newContent;
+    /**
+     * Create a new container holding a copy of the values in the provided array.
+     *
+     * @param values array with values in increasing unsigned short order, all of which the container holds.
+     */
+    public ArrayContainer(final short[] values) {
+        this(values.length, values, 0, values.length);
     }
 
     @Override
@@ -276,7 +348,7 @@ public class ArrayContainer extends Container {
     }
 
     private Container isetImplSecondHalf(final short x, final int loc, final PositionHint positionHintOut) {
-        if (cardinality >= content.length) {
+        if (cardinality >= capacity()) {
             increaseCapacity();
         }
         // insertion : shift the elements > x by one position to
@@ -355,7 +427,7 @@ public class ArrayContainer extends Container {
         if (value2.isEmpty()) {
             return cowRef();
         }
-        final ArrayContainer answer = new ArrayContainer(content.length);
+        final ArrayContainer answer = new ArrayContainer(capacity());
         int pos = 0;
         for (int k = 0; k < cardinality; ++k) {
             short val = content[k];
@@ -512,7 +584,7 @@ public class ArrayContainer extends Container {
                 return a.iset(x);
             }
             final ArrayContainer ans = deepcopyIfShared();
-            if (ans.cardinality >= ans.content.length) {
+            if (ans.cardinality >= ans.capacity()) {
                 ans.increaseCapacity();
             }
             // insertion : shift the elements > x by one position to
@@ -713,8 +785,8 @@ public class ArrayContainer extends Container {
          * always
          */
         final ArrayContainer ans;
-        if (newcardinality > content.length) {
-            short[] destination = new short[calculateCapacity(newcardinality)];
+        if (newcardinality > capacity()) {
+            short[] destination = newContent(calculateCapacity(newcardinality));
             // if b > 0, we copy from 0 to b. Do nothing otherwise.
             System.arraycopy(content, 0, destination, 0, indexstart);
             // set values from b to e
@@ -728,15 +800,15 @@ public class ArrayContainer extends Container {
             System.arraycopy(content, indexend,
                     destination, indexstart + rangelength,
                     cardinality - indexend);
-            if (shared) {
-                ans = new ArrayContainer(destination, newcardinality);
+            if (isShared()) {
+                ans = makeByWrapping(destination, newcardinality);
             } else {
                 content = destination;
                 cardinality = newcardinality;
                 ans = this;
             }
         } else {
-            if (shared) {
+            if (isShared()) {
                 ans = new ArrayContainer(calculateCapacity(newcardinality));
                 System.arraycopy(content, 0, ans.content, 0, indexstart);
             } else {
@@ -768,11 +840,12 @@ public class ArrayContainer extends Container {
         }
         final ArrayContainer ans;
         final int firstIndexNewRange = cardinality;
-        if (shared || newCardinality > content.length) {
-            short[] destination = new short[appendCapacity(newCardinality)];
+        final boolean shared = isShared();
+        if (shared || newCardinality > capacity()) {
+            short[] destination = newContent(appendCapacity(newCardinality));
             System.arraycopy(content, 0, destination, 0, cardinality);
             if (shared) {
-                ans = new ArrayContainer(destination, newCardinality);
+                ans = makeByWrapping(destination, newCardinality);
             } else {
                 content = destination;
                 cardinality = newCardinality;
@@ -849,24 +922,21 @@ public class ArrayContainer extends Container {
     }
 
     private static int nextCapacity(final int oldCapacity) {
-        return (oldCapacity == 0) ? DEFAULT_INIT_SIZE
-                : oldCapacity < 64 ? shortArraySizeRounding(oldCapacity * 2)
-                        : oldCapacity < 1067 ? shortArraySizeRounding(oldCapacity * 3 / 2)
-                                : shortArraySizeRounding(oldCapacity * 5 / 4);
+        return (oldCapacity == 0) ? DEFAULT_INIT_CAPACITY
+                : oldCapacity < 64 ? oldCapacity * 2
+                        : oldCapacity < 1067 ? oldCapacity * 3 / 2
+                                : oldCapacity * 5 / 4;
     }
 
     // temporarily allow an illegally large size, as long as the operation creating
     // the illegal container does not return it.
     private void increaseCapacity(final boolean allowIllegalSize) {
-        int newCapacity = nextCapacity(content.length);
-        if (newCapacity > ArrayContainer.DEFAULT_MAX_SIZE && !allowIllegalSize) {
-            newCapacity = ArrayContainer.DEFAULT_MAX_SIZE;
-        }
-        // if we are within ~1/16th of the max, go to max
+        int newCapacity = nextCapacity(capacity());
+        // if we are within ~1/16th of the max, or over, go to max
         if (newCapacity > ArrayContainer.DEFAULT_MAX_SIZE - 256 && !allowIllegalSize) {
             newCapacity = ArrayContainer.DEFAULT_MAX_SIZE;
         }
-        final short[] vs = new short[newCapacity];
+        final short[] vs = newContent(newCapacity);
         System.arraycopy(content, 0, vs, 0, cardinality);
         content = vs;
     }
@@ -888,18 +958,14 @@ public class ArrayContainer extends Container {
      * @return The capacity to allocate, always at least {@code newCardinality}
      */
     private int appendCapacity(final int newCardinality) {
-        final int newCapacity = Math.max(shortArraySizeRounding(newCardinality), nextCapacity(content.length));
+        final int newCapacity = Math.max(newCardinality, nextCapacity(capacity()));
         // Within ~1/16th of the max there is no point holding back room to grow.
         return newCapacity > DEFAULT_MAX_SIZE - 256 ? DEFAULT_MAX_SIZE : newCapacity;
     }
 
-    private int calculateCapacity(final int min) {
-        int newCapacity = shortArraySizeRounding(min);
+    private static int calculateCapacity(final int min) {
         // if we are within ~1/16th of the max, or over, go to max
-        if (newCapacity > ArrayContainer.DEFAULT_MAX_SIZE - 256) {
-            newCapacity = ArrayContainer.DEFAULT_MAX_SIZE;
-        }
-        return newCapacity;
+        return min > ArrayContainer.DEFAULT_MAX_SIZE - 256 ? ArrayContainer.DEFAULT_MAX_SIZE : min;
     }
 
     @Override
@@ -930,13 +996,13 @@ public class ArrayContainer extends Container {
             if (newCardinality > DEFAULT_MAX_SIZE) {
                 return toBiggerCardinalityContainer(newCardinality).inot(firstOfRange, exclusiveEndOfRange);
             }
-            if (shared) {
+            if (isShared()) {
                 ans = new ArrayContainer(calculateCapacity(newCardinality));
                 System.arraycopy(content, 0, ans.content, 0, lastIndex + 1);
             } else {
                 ans = this;
-                if (newCardinality > content.length) {
-                    content = new short[calculateCapacity(newCardinality)];
+                if (newCardinality > capacity()) {
+                    content = newContent(calculateCapacity(newCardinality));
                     System.arraycopy(src, 0, content, 0, lastIndex + 1);
                 }
             }
@@ -945,11 +1011,11 @@ public class ArrayContainer extends Container {
                     cardinality - 1 - lastIndex);
             ans.negateRange(newValuesInRange, startIndex, lastIndex, firstOfRange, exclusiveEndOfRange);
         } else { // no alloc expansion needed
-            if (shared) {
+            if (isShared()) {
                 if (cardinalityChange == 0) {
                     ans = deepCopy();
                 } else {
-                    ans = new ArrayContainer(content.length);
+                    ans = new ArrayContainer(capacity());
                     System.arraycopy(content, 0, ans.content, 0, lastIndex + 1);
                 }
             } else {
@@ -969,7 +1035,7 @@ public class ArrayContainer extends Container {
 
     @Override
     public Container ior(final ArrayContainer value2) {
-        if (shared) {
+        if (isShared()) {
             return or(value2);
         }
         if (value2.isEmpty()) {
@@ -1002,7 +1068,7 @@ public class ArrayContainer extends Container {
             }
             return bc;
         }
-        if (sumOfCardinalities >= content.length) {
+        if (sumOfCardinalities >= capacity()) {
             int newCapacity = calculateCapacity(sumOfCardinalities);
             final ArrayContainer ans = new ArrayContainer(newCapacity);
             ans.cardinality =
@@ -1092,7 +1158,7 @@ public class ArrayContainer extends Container {
             return Container.twoValues(content[i0], content[i1]);
         }
         final ArrayContainer ans;
-        if (inPlace && !shared) {
+        if (inPlace && !isShared()) {
             ans = this;
         } else {
             ans = new ArrayContainer(calculateCapacity(newCardinality));
@@ -1295,7 +1361,7 @@ public class ArrayContainer extends Container {
     }
 
     private void forceAppend(final short val) {
-        if (cardinality == content.length) {
+        if (cardinality == capacity()) {
             increaseCapacity(true);
         }
         content[cardinality++] = val;
@@ -1443,11 +1509,10 @@ public class ArrayContainer extends Container {
     }
 
     private void compact() {
-        if (shared || content.length == cardinality || (cardinality == 0 && content.length == DEFAULT_INIT_SIZE)) {
+        if (isShared() || capacity() == cardinality || (cardinality == 0 && capacity() == DEFAULT_INIT_CAPACITY)) {
             return;
         }
-        final short[] newContent =
-                new short[cardinality == 0 ? DEFAULT_INIT_SIZE : shortArraySizeRounding(cardinality)];
+        final short[] newContent = newContent(cardinality == 0 ? DEFAULT_INIT_CAPACITY : cardinality);
         System.arraycopy(content, 0, newContent, 0, cardinality);
         content = newContent;
     }
@@ -1500,7 +1565,7 @@ public class ArrayContainer extends Container {
 
     @Override
     public Container iandRange(final int start, final int end) {
-        return andRangeImpl(!shared, start, end);
+        return andRangeImpl(!isShared(), start, end);
     }
 
     @Override
@@ -1867,17 +1932,11 @@ public class ArrayContainer extends Container {
 
     @Override
     public final void setCopyOnWrite() {
-        if (shared) {
-            return;
-        }
-        shared = true;
-        onCopyOnWrite();
+        markContentShared(content);
     }
 
-    protected void onCopyOnWrite() {}
-
     private ArrayContainer deepcopyIfShared() {
-        return shared ? deepCopy() : this;
+        return isShared() ? deepCopy() : this;
     }
 
     @Override
@@ -1909,6 +1968,6 @@ public class ArrayContainer extends Container {
 
     @Override
     public boolean isShared() {
-        return shared;
+        return isContentShared(content);
     }
 }

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
@@ -101,9 +101,21 @@ public class ArrayContainer extends Container {
         return shortArraySizeRounding(capacity + 1);
     }
 
+    /**
+     * A fresh, unshared content array able to hold {@code capacity} values, for a caller that fills it and then hands
+     * it to {@link #makeByWrapping(short[], int)}: the values go at indices {@code [0, capacity)}, and the array's
+     * reserved last slot and any rounding padding beyond them are already in place.
+     *
+     * @param capacity the number of values the array must be able to hold
+     * @return a new array, sized as this container would size its own
+     */
+    public static short[] allocateContent(final int capacity) {
+        return new short[contentLength(capacity)];
+    }
+
     /** A fresh, unshared content array able to hold {@code capacity} values. */
     private static short[] newContent(final int capacity) {
-        return new short[contentLength(capacity)];
+        return allocateContent(capacity);
     }
 
     /** The number of values the content array can hold. */
@@ -230,16 +242,18 @@ public class ArrayContainer extends Container {
     }
 
     /**
-     * Create a new container holding a copy of the values in the provided array.
+     * Create a new container holding a copy of the values in the provided array. A convenience for tests; production
+     * code fills an array from {@link #allocateContent(int)} and hands it to {@link #makeByWrapping(short[], int)}
+     * instead, which allocates once.
      *
      * <p>
-     * Unlike {@link #makeByWrapping(short[], int)}, the argument is plain values only: every element is a value, and
-     * there is no reserved slot in it. The container copies them into a content array of its own, allocated with the
-     * reserved last slot, and does not keep a reference to the argument.
+     * Unlike {@code makeByWrapping}, the argument is plain values only: every element is a value, and there is no
+     * reserved slot in it. The container copies them into a content array of its own, allocated with the reserved last
+     * slot, and does not keep a reference to the argument.
      *
      * @param values array with values in increasing unsigned short order, all of which the container holds.
      */
-    public ArrayContainer(final short[] values) {
+    ArrayContainer(final short[] values) {
         this(values.length, values, 0, values.length);
     }
 
@@ -1514,10 +1528,12 @@ public class ArrayContainer extends Container {
     }
 
     private void compact() {
-        if (isShared() || capacity() == cardinality || (cardinality == 0 && capacity() == DEFAULT_INIT_CAPACITY)) {
+        final int compactCapacity = cardinality == 0 ? DEFAULT_INIT_CAPACITY : cardinality;
+        // Nothing to gain when the array is already the length the allocator would round a compact one up to.
+        if (isShared() || content.length == contentLength(compactCapacity)) {
             return;
         }
-        final short[] newContent = newContent(cardinality == 0 ? DEFAULT_INIT_CAPACITY : cardinality);
+        final short[] newContent = newContent(compactCapacity);
         System.arraycopy(content, 0, newContent, 0, cardinality);
         content = newContent;
     }

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ArrayContainer.java
@@ -232,6 +232,11 @@ public class ArrayContainer extends Container {
     /**
      * Create a new container holding a copy of the values in the provided array.
      *
+     * <p>
+     * Unlike {@link #makeByWrapping(short[], int)}, the argument is plain values only: every element is a value, and
+     * there is no reserved slot in it. The container copies them into a content array of its own, allocated with the
+     * reserved last slot, and does not keep a reference to the argument.
+     *
      * @param values array with values in increasing unsigned short order, all of which the container holds.
      */
     public ArrayContainer(final short[] values) {

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/BitmapContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/BitmapContainer.java
@@ -262,7 +262,7 @@ public final class BitmapContainer extends Container implements Cloneable {
 
     @Override
     public ArrayContainer and(final ArrayContainer value2) {
-        final ArrayContainer answer = new ArrayContainer(value2.content.length);
+        final ArrayContainer answer = new ArrayContainer(value2.capacity());
         int c = value2.cardinality;
         for (int k = 0; k < c; ++k) {
             short v = value2.content[k];

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/Container.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/Container.java
@@ -74,9 +74,7 @@ public abstract class Container {
 
     public static Container singleton(final short v) {
         if (smallContainersDisabled()) {
-            final short[] vs = new short[shortArraySizeRounding(1)];
-            vs[0] = v;
-            return new ArrayContainer(vs, 1);
+            return new ArrayContainer(v);
         }
         return new SingletonContainer(v);
     }
@@ -129,10 +127,7 @@ public abstract class Container {
             }
         }
         if (smallContainersDisabled()) {
-            final short[] vs = new short[shortArraySizeRounding(2)];
-            vs[0] = v1;
-            vs[1] = v2;
-            return new ArrayContainer(vs, 2);
+            return new ArrayContainer(v1, v2);
         }
         if (iv2 - 1 == iv1) {
             return Container.singleRange(iv1, iv2 + 1);

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/SingletonContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/SingletonContainer.java
@@ -636,7 +636,7 @@ public final class SingletonContainer extends ImmutableContainer {
 
     @Override
     public Container toLargeContainer() {
-        return new ArrayContainer(new short[] {value});
+        return new ArrayContainer(value);
     }
 
     @Override

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/TwoValuesContainer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/TwoValuesContainer.java
@@ -983,7 +983,7 @@ public final class TwoValuesContainer extends ImmutableContainer {
 
     @Override
     public Container toLargeContainer() {
-        return new ArrayContainer(new short[] {v1, v2});
+        return new ArrayContainer(v1, v2);
     }
 
     @Override

--- a/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
+++ b/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
@@ -28,6 +28,79 @@ public class TestArrayContainer extends TestContainerBase {
         assertSameContents(ac1, ac2);
     }
 
+    /**
+     * The last element of the content array is reserved for the shared flag: filling the container to its capacity,
+     * and growing it, never writes a value there.
+     */
+    @Test
+    public void testReservedSlotIsNeverAValue() {
+        final ArrayContainer ac = new ArrayContainer();
+        assertEquals(ac.getContent().length - 1, ac.capacity());
+        // Enough values to grow the array a couple of times, while staying far too few for a different container type.
+        final int values = 3 * ac.capacity() + 2;
+        Container c = ac;
+        for (int v = 0; v < 3 * values; v += 3) {
+            c = c.iset((short) v);
+            assertSame("stays an ArrayContainer while small", ac, c);
+            final short[] content = ac.getContent();
+            assertEquals(content.length - 1, ac.capacity());
+            assertTrue("cardinality never reaches the reserved slot", ac.getCardinality() <= ac.capacity());
+            assertEquals("the reserved slot is untouched", 0, content[content.length - 1]);
+            assertFalse(ArrayContainer.isContentShared(content));
+        }
+        ac.validate();
+    }
+
+    /** Marking a container shared marks its array, which is where anyone holding the array reads the flag. */
+    @Test
+    public void testSetCopyOnWriteMarksTheContentArray() {
+        final ArrayContainer ac = new ArrayContainer(5, 15);
+        final short[] content = ac.getContent();
+        assertFalse(ac.isShared());
+        assertFalse(ArrayContainer.isContentShared(content));
+
+        ac.setCopyOnWrite();
+        assertTrue(ac.isShared());
+        assertTrue(ArrayContainer.isContentShared(content));
+
+        final Container r = ac.iset((short) 20);
+        assertNotSame("a shared container is copied, not edited in place", ac, r);
+        assertSame("the shared container keeps its array", content, ac.getContent());
+        assertEquals(10, ac.getCardinality());
+        assertEquals(11, r.getCardinality());
+        assertFalse("the copy is the caller's own", r.isShared());
+
+        // The flag is a property of the array: a container over a marked array is shared.
+        final ArrayContainer over = ArrayContainer.makeByWrapping(content, ac.getCardinality());
+        assertTrue(over.isShared());
+    }
+
+    /** An array handed to the container must leave room for the reserved slot. */
+    @Test
+    public void testWrappedArrayMustHaveRoomForTheReservedSlot() {
+        final short[] full = {1, 2, 3};
+        try {
+            ArrayContainer.makeByWrapping(full, full.length);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+        final short[] withRoom = {1, 2, 3, 0};
+        final ArrayContainer ac = ArrayContainer.makeByWrapping(withRoom, 3);
+        assertEquals(3, ac.getCardinality());
+        assertEquals(3, ac.capacity());
+        assertSame(withRoom, ac.getContent());
+        ac.validate();
+    }
+
+    /** DEFAULT_MAX_SIZE is chosen so that the largest ArrayContainer's array is exactly the size of a bitmap. */
+    @Test
+    public void testMaxSizeContentArrayIsABitmapsSize() {
+        final ArrayContainer ac = new ArrayContainer(ArrayContainer.DEFAULT_MAX_SIZE);
+        assertEquals(ArrayContainer.DEFAULT_MAX_SIZE, ac.capacity());
+        final int arrayHeaderBytes = 12;
+        assertEquals(BitmapContainer.BITMAP_SIZE_IN_BYTES, arrayHeaderBytes + Short.BYTES * ac.getContent().length);
+    }
+
     @Test
     public void testIandNot() {
         ArrayContainer ac1 = new ArrayContainer(5, 15);

--- a/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
+++ b/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
@@ -96,11 +96,9 @@ public class TestArrayContainer extends TestContainerBase {
     @Test
     public void testWrappedArrayMustHaveRoomForTheReservedSlot() {
         final short[] full = {1, 2, 3};
-        try {
-            ArrayContainer.makeByWrapping(full, full.length);
-            fail("expected IllegalArgumentException");
-        } catch (IllegalArgumentException expected) {
-        }
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> ArrayContainer.makeByWrapping(full, full.length));
+        assertEquals(IllegalArgumentException.class, e.getClass());
         final short[] withRoom = {1, 2, 3, 0};
         final ArrayContainer ac = ArrayContainer.makeByWrapping(withRoom, 3);
         assertEquals(3, ac.getCardinality());

--- a/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
+++ b/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestArrayContainer.java
@@ -75,6 +75,23 @@ public class TestArrayContainer extends TestContainerBase {
         assertTrue(over.isShared());
     }
 
+    /**
+     * The small fixed-arity constructors, which also stand in for the singleton and two-value containers when those
+     * are disabled, allocate with room for the reserved slot like every other path.
+     */
+    @Test
+    public void testSmallConstructorsReserveTheSlot() {
+        for (final ArrayContainer ac : new ArrayContainer[] {
+                new ArrayContainer((short) 7),
+                new ArrayContainer((short) 7, (short) 9),
+                new ArrayContainer((short) 7, (short) 9, (short) 11)}) {
+            assertTrue(ac.getCardinality() <= ac.capacity());
+            assertEquals(ac.getContent().length - 1, ac.capacity());
+            assertFalse(ac.isShared());
+            ac.validate();
+        }
+    }
+
     /** An array handed to the container must leave room for the reserved slot. */
     @Test
     public void testWrappedArrayMustHaveRoomForTheReservedSlot() {

--- a/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestContainerEmptyRangeOps.java
+++ b/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestContainerEmptyRangeOps.java
@@ -22,13 +22,13 @@ public class TestContainerEmptyRangeOps {
     public void testArrayContainerInotOverAnEmptyRange() {
         final List<Integer> expected = List.of(10, 20, 30);
         for (final int at : new int[] {0, 1, 10, 20, 65535}) {
-            final ArrayContainer c = new ArrayContainer(new short[] {10, 20, 30}, 3);
+            final ArrayContainer c = new ArrayContainer(new short[] {10, 20, 30});
             final Container after = c.inot(at, at);
             assertEquals("inot(" + at + ", " + at + ")", expected, valuesOf(after));
             assertEquals("inot(" + at + ", " + at + ") cardinality", 3, after.getCardinality());
         }
         // not already handles this; keep the two in step.
-        final ArrayContainer c = new ArrayContainer(new short[] {10, 20, 30}, 3);
+        final ArrayContainer c = new ArrayContainer(new short[] {10, 20, 30});
         assertEquals("not(0, 0)", expected, valuesOf(c.not(0, 0)));
     }
 
@@ -113,7 +113,7 @@ public class TestContainerEmptyRangeOps {
     @Test
     public void testOtherImplementationsAgreeOnDegenerateRanges() {
         for (final Container c : new Container[] {
-                new ArrayContainer(new short[] {10, 20, 30}, 3),
+                new ArrayContainer(new short[] {10, 20, 30}),
                 new RunContainer(10, 11, 20, 21).iset((short) 30),
                 new BitmapContainer().iset((short) 10).iset((short) 20).iset((short) 30),
         }) {

--- a/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestTwoValuesContainerSelectRanges.java
+++ b/Container/src/test/java/io/deephaven/engine/rowset/impl/rsp/container/TestTwoValuesContainerSelectRanges.java
@@ -48,7 +48,7 @@ public class TestTwoValuesContainerSelectRanges {
         final List<Integer> expected = List.of(a, a + 1, b, b + 1);
         for (final Container c : new Container[] {
                 Container.twoValues((short) a, (short) b),
-                new ArrayContainer(new short[] {(short) a, (short) b}, 2),
+                new ArrayContainer(new short[] {(short) a, (short) b}),
                 new RunContainer(a, a + 1, b, b + 1),
                 new BitmapContainer().iset((short) a).iset((short) b),
         }) {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
@@ -510,15 +510,11 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         }
 
         public void init(final RspArray<?> arr, final int arrIdx) {
-            init(arr, arrIdx, arr.spanInfos[arrIdx], arr.spans[arrIdx]);
+            init(arr.spanInfos[arrIdx], arr.spans[arrIdx]);
         }
 
-        /**
-         * Load the view with a span already read from {@code arr} at {@code arrIdx}. The view keeps no reference to the
-         * array: nothing it does writes back into the array's words, so the first two parameters only say where the
-         * span came from.
-         */
-        public void init(final RspArray<?> arr, final int arrIdx, final long spanInfo, final Object span) {
+        /** Load the view with a span's word and object, already read from their array. */
+        public void init(final long spanInfo, final Object span) {
             this.spanInfo = spanInfo;
             this.span = span;
         }
@@ -1026,7 +1022,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             final long card = endOffset + 1;
             final Object srcSpan = src.spans[isrc];
             if (!isSingletonSpan(srcSpan)) {
-                try (SpanView res = wd.get().borrowSpanView(src, isrc, srcSpanInfo, srcSpan)) {
+                try (SpanView res = wd.get().borrowSpanView(srcSpanInfo, srcSpan)) {
                     final Container csrc = res.getContainer();
                     // This can't be the full container or we would have copied it earlier.
                     if (endOffset == 0) {
@@ -1159,10 +1155,6 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
          * Releases the RspArray reference.
          */
         void release();
-
-        RspArray arr();
-
-        int arrIdx();
     }
 
     public interface SpanCursorForward extends SpanCursor {
@@ -1267,16 +1259,6 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             ra.release();
             ra = null;
         }
-
-        @Override
-        public RspArray arr() {
-            return ra;
-        }
-
-        @Override
-        public int arrIdx() {
-            return si;
-        }
     }
 
     public RspRangeIterator getRangeIterator() {
@@ -1358,16 +1340,6 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             }
             ra.release();
             ra = null;
-        }
-
-        @Override
-        public RspArray arr() {
-            return ra;
-        }
-
-        @Override
-        public int arrIdx() {
-            return si;
         }
     }
 
@@ -1903,7 +1875,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             final short[] contents = (short[]) o;
             if (contents.length < 3 || contents.length > 12) {
                 final long spanInfo = spanInfos[i];
-                try (SpanView res = workDataPerThread.get().borrowSpanView(this, i, spanInfo, contents)) {
+                try (SpanView res = workDataPerThread.get().borrowSpanView(spanInfo, contents)) {
                     final Container c = res.getContainer();
                     final Container prevContainer = c.runOptimize();
                     if (prevContainer != c) {
@@ -3043,7 +3015,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             final WorkData wd) {
         final Object otherSpan = other.spans[otherIdx];
         final long otherSpanInfo = other.getSpanInfo(otherIdx) + shiftAmount;
-        try (SpanView otherView = wd.borrowSpanView(other, otherIdx, otherSpanInfo, otherSpan)) {
+        try (SpanView otherView = wd.borrowSpanView(otherSpanInfo, otherSpan)) {
             final long otherKey = otherView.getKey();
             final long otherflen = otherView.getFullBlockSpanLen();
             final int orIdx = getSpanIndex(startPos, otherKey);
@@ -3188,9 +3160,9 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             return rspArraysBuf;
         }
 
-        public SpanView borrowSpanView(final RspArray arr, final int arrIdx, final long spanInfo, final Object span) {
+        public SpanView borrowSpanView(final long spanInfo, final Object span) {
             final SpanView sv = borrowSpanView();
-            sv.init(arr, arrIdx, spanInfo, span);
+            sv.init(spanInfo, span);
             return sv;
         }
 
@@ -4246,7 +4218,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         final int rStart = (int) (resultStart - key);
         final int rEndExclusive = (int) (resultEnd - key) + 1;
         final Container result;
-        try (SpanView view = workDataPerThread.get().borrowSpanView(this, i, spanInfo, span)) {
+        try (SpanView view = workDataPerThread.get().borrowSpanView(spanInfo, span)) {
             final Container c = view.getContainer();
             result = c.andRange(rStart, rEndExclusive);
             if (result.isEmpty()) {
@@ -4709,7 +4681,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             final PendingSpanInserts pending,
             final WorkData wd) {
         final Object span = spans[i];
-        try (SpanView view = wd.borrowSpanView(this, i, spanInfo, span)) {
+        try (SpanView view = wd.borrowSpanView(spanInfo, span)) {
             final long flen = view.getFullBlockSpanLen();
             if (flen > 0) {
                 final long sLastPlusOne = key + BLOCK_SIZE * flen;

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
@@ -406,20 +406,11 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
     }
 
     /**
-     * The bits of a packed ArrayContainer's word that hold its cardinality: all sixteen low bits, which an
-     * ArrayContainer's cardinality never fills. Nothing else is encoded in the word. In particular the container's
-     * shared flag is not: it is held in the reserved last slot of the {@code short[]} itself, see
-     * {@link ArrayContainer#getContent()}, so that an RspArray sharing the container from a source marks the array
-     * rather than writing into the source's words.
-     *
-     * <p>
-     * That matters because, per {@link io.deephaven.engine.rowset.impl.RefCountedCow}, a reader may derive from a
-     * source while the source's single owner mutates it in place; the reader's result is discarded once the clock shows
-     * it stale, but anything the reader wrote into the owner's arrays would be permanent. A write to the shared
-     * {@code short[]} can only affect that array: if the owner has meanwhile replaced the span, the array is orphaned
-     * and the write is harmless, and if not, the owner sees the flag on the very array it is about to edit. A word, by
-     * contrast, describes whatever span currently sits at the index, and cannot be written safely by anyone but the
-     * owner.
+     * The low bits of a packed ArrayContainer's word hold its cardinality; the high bits hold its key. Only the owner
+     * writes the word. The container's shared flag lives in the reserved last slot of the {@code short[]} itself (see
+     * {@link ArrayContainer#getContent()}), because per {@link io.deephaven.engine.rowset.impl.RefCountedCow} a reader
+     * may share the container while the owner is mutating in place, and the array the reader holds is the only thing it
+     * can mark without risk of writing over a span the owner has since replaced.
      */
     private static final long SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK = BLOCK_LAST;
 

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
@@ -329,17 +329,13 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         modifiedSpan(i);
     }
 
-    public static long getPackedInfoLowBits(final ArrayContainer ac) {
-        final long sharedBit = ac.isShared() ? SPANINFO_ARRAYCONTAINER_SHARED_BITMASK : 0L;
-        final long cardinalityBits = SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK & (long) ac.getCardinality();
-        return sharedBit | cardinalityBits;
-    }
-
     protected static void setContainerSpanRaw(
             final long[] spanInfos, final Object[] spans, final int i, final long key, final Container container) {
         if (container instanceof ArrayContainer) {
+            // An ArrayContainer is packed: its short[] alone is the span, and the word carries its cardinality. The
+            // container's shared flag needs no room in the word because it lives in the array's reserved last slot.
             final ArrayContainer ac = (ArrayContainer) container;
-            spanInfos[i] = key | getPackedInfoLowBits(ac);
+            spanInfos[i] = key | (SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK & (long) ac.getCardinality());
             spans[i] = ac.getContent();
             return;
         }
@@ -372,10 +368,18 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         ++size;
     }
 
+    /**
+     * Store at {@code i} a share of the container span the caller observed at {@code srcIdx} of {@code src}.
+     *
+     * @param srcSpanInfo the source's word for the span as observed: for a packed ArrayContainer, its key and
+     *        cardinality, which the copy stores as is; for a Container, its key
+     * @param srcContainer the source's span as observed, a {@code short[]} or a {@link Container}
+     */
     protected void setSharedContainerMaybePackedRaw(
             final int i, final RspArray src, final int srcIdx, final long srcSpanInfo, final Object srcContainer) {
         if (srcContainer instanceof short[]) {
-            spanInfos[i] = (src.spanInfos[srcIdx] |= SPANINFO_ARRAYCONTAINER_SHARED_BITMASK);
+            ArrayContainer.markContentShared((short[]) srcContainer);
+            spanInfos[i] = srcSpanInfo;
             spans[i] = srcContainer;
             return;
         }
@@ -401,9 +405,23 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         dstSpans[dstIdx] = srcSpans[srcIdx];
     }
 
-    private static final long SPANINFO_ARRAYCONTAINER_SHARED_BITMASK = (1L << 15);
-    private static final long SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK =
-            ~SPANINFO_ARRAYCONTAINER_SHARED_BITMASK & (long) BLOCK_LAST;
+    /**
+     * The bits of a packed ArrayContainer's word that hold its cardinality: all sixteen low bits, which an
+     * ArrayContainer's cardinality never fills. Nothing else is encoded in the word. In particular the container's
+     * shared flag is not: it is held in the reserved last slot of the {@code short[]} itself, see
+     * {@link ArrayContainer#getContent()}, so that an RspArray sharing the container from a source marks the array
+     * rather than writing into the source's words.
+     *
+     * <p>
+     * That matters because, per {@link io.deephaven.engine.rowset.impl.RefCountedCow}, a reader may derive from a
+     * source while the source's single owner mutates it in place; the reader's result is discarded once the clock shows
+     * it stale, but anything the reader wrote into the owner's arrays would be permanent. A write to the shared
+     * {@code short[]} can only affect that array: if the owner has meanwhile replaced the span, the array is orphaned
+     * and the write is harmless, and if not, the owner sees the flag on the very array it is about to edit. A word, by
+     * contrast, describes whatever span currently sits at the index, and cannot be written safely by anyone but the
+     * owner.
+     */
+    private static final long SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK = BLOCK_LAST;
 
     // shiftAmount is a multiple of BLOCK_SIZE.
     protected void copyKeyAndSpanMaybeSharing(
@@ -411,10 +429,10 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             final RspArray src, final int srcIdx,
             final long[] dstSpanInfos, final Object[] dstSpans, final int dstIdx,
             final boolean tryShare) {
-        Object span = src.spans[srcIdx];
+        final Object span = src.spans[srcIdx];
         if (tryShare && src.shareContainers()) {
             if (span instanceof short[]) {
-                src.spanInfos[srcIdx] |= SPANINFO_ARRAYCONTAINER_SHARED_BITMASK;
+                ArrayContainer.markContentShared((short[]) span);
             } else if (span instanceof Container) {
                 final Container c = (Container) span;
                 c.setCopyOnWrite();
@@ -453,28 +471,24 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
     protected static final class SpanView extends ArrayContainer
             implements AutoCloseable {
         private final SpanViewRecycler recycler;
-        // The original array and index for which we loaded; we need to keep the reference
-        // for the cases where we need to update it (eg, setting a copy on write shared flag for an ArrayContainer
-        // stored as short[]).
-        private RspArray<?> arr;
-        private int arrIdx;
         private long spanInfo;
         private Object span;
 
         public SpanView(final SpanViewRecycler recycler) {
-            super(null, 0, false);
+            super(null, 0);
             this.recycler = recycler;
         }
 
         // The returned container is guaranteed to be valid until the next init() or close().
         public Container getContainer() {
             if (span instanceof short[]) {
-                shared = (spanInfo & SPANINFO_ARRAYCONTAINER_SHARED_BITMASK) != 0;
+                // The view is the packed ArrayContainer itself, over the span's short[]: its cardinality comes from
+                // the word, and its shared flag, as for any ArrayContainer, from the array's reserved last slot.
+                // Marking the view shared through setCopyOnWrite thus marks the span's array itself.
                 cardinality = (int) (spanInfo & SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK);
                 content = (short[]) span;
                 return this;
             }
-            shared = false;
             cardinality = 0;
             content = null;
             return (Container) span;
@@ -508,21 +522,18 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             init(arr, arrIdx, arr.spanInfos[arrIdx], arr.spans[arrIdx]);
         }
 
+        /**
+         * Load the view with a span already read from {@code arr} at {@code arrIdx}. The view keeps no reference to the
+         * array: nothing it does writes back into the array's words, so the first two parameters only say where the
+         * span came from.
+         */
         public void init(final RspArray<?> arr, final int arrIdx, final long spanInfo, final Object span) {
-            this.arr = arr;
-            this.arrIdx = arrIdx;
             this.spanInfo = spanInfo;
             this.span = span;
         }
 
-        @Override
-        protected void onCopyOnWrite() {
-            arr.spanInfos[arrIdx] |= SPANINFO_ARRAYCONTAINER_SHARED_BITMASK;
-        }
-
         public void reset() {
             content = null;
-            arr = null;
             span = null;
         }
 
@@ -748,11 +759,10 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
                 continue;
             }
             if (span instanceof short[]) {
-                // A packed ArrayContainer's shared flag lives in its owner's spanInfo word, so unlike a Container --
-                // whose flag travels with the object -- marking only this copy would leave the source believing it
-                // still owns the short[] exclusively, free to edit it in place underneath us.
-                spanInfos[i] |= SPANINFO_ARRAYCONTAINER_SHARED_BITMASK;
-                src.spanInfos[isrc] |= SPANINFO_ARRAYCONTAINER_SHARED_BITMASK;
+                // A packed ArrayContainer's shared flag lives in the short[] itself, so as for a Container, whose flag
+                // travels with the object, marking it once covers both sides: the source, which must no longer edit
+                // the short[] in place, and this copy.
+                ArrayContainer.markContentShared((short[]) span);
                 continue;
             }
             // span instanceof Container
@@ -4237,7 +4247,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             resultEnd = end;
         } else {
             if (resultStart == key) {
-                r.appendSharedContainerMaybePacked(this, i, key, span);
+                r.appendSharedContainerMaybePacked(this, i, spanInfo, span);
                 return;
             }
             resultEnd = blockLast;
@@ -5060,6 +5070,14 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
                             }
                             return false;
                         }
+                        if (s instanceof short[] && ((short[]) s).length <= c.getCardinality()) {
+                            if (doAssert) {
+                                final String m = str + ": packed ArrayContainer short[] has no reserved slot i=" + i
+                                        + ", length=" + ((short[]) s).length + ", cardinality=" + c.getCardinality();
+                                Assert.assertion(false, m);
+                            }
+                            return false;
+                        }
                         if (c.isAllOnes()) {
                             if (doAssert) {
                                 final String m = str + ": full RB container found i=" + i + ", size=" + size;
@@ -5436,8 +5454,9 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         for (int i = 0; i < size; ++i) {
             final Object o = spans[i];
             if (o instanceof short[]) {
+                // The array's reserved last slot can never hold a value, so it is not capacity going spare.
                 used += spanInfos[i] & SPANINFO_ARRAYCONTAINER_CARDINALITY_BITMASK;
-                allocated += ((short[]) o).length;
+                allocated += ((short[]) o).length - 1;
                 continue;
             }
             if (!(o instanceof Container)) {
@@ -5490,7 +5509,8 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
                 arrayContainersCardinality.accept(card);
                 final long allocated = ((short[]) o).length;
                 arrayContainersBytesAllocated.accept(allocated);
-                arrayContainersBytesUnused.accept(allocated - card);
+                // Unused is spare value capacity, which excludes the array's reserved last slot.
+                arrayContainersBytesUnused.accept(allocated - 1 - card);
                 continue;
             }
             if (!(o instanceof Container)) { // full block span

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
@@ -364,11 +364,12 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
     private static Container makeValuesContainer(final LongChunk<OrderedRowKeys> values,
             final int offset, final int length) {
         if (length <= ArrayContainer.SWITCH_CONTAINER_CARDINALITY_THRESHOLD) {
-            final short[] valuesArray = new short[length];
+            // Fill an array the container can take over as is, rather than one it would have to copy.
+            final short[] valuesArray = ArrayContainer.allocateContent(length);
             for (int vi = 0; vi < length; ++vi) {
                 valuesArray[vi] = lowBitsAsShort(values.get(vi + offset));
             }
-            return new ArrayContainer(valuesArray);
+            return ArrayContainer.makeByWrapping(valuesArray, length);
         }
         final BitmapContainer bitmapContainer = new BitmapContainer();
         for (int vi = 0; vi < length; ++vi) {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
@@ -185,7 +185,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
                     if (getFullBlockSpanLen(existingSpanInfo, existingSpan) >= 1) {
                         continue;
                     }
-                    ourView.init(this, spanIndex, existingSpanInfo, existingSpan);
+                    ourView.init(existingSpanInfo, existingSpan);
                     container = ourView.getContainer();
                     existing = true;
                 }
@@ -634,7 +634,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
                 result = Container.singleRange(startLowBits, endExclusive);
             }
         } else {
-            view = workDataPerThread.get().borrowSpanView(this, i, spanInfos[i], span);
+            view = workDataPerThread.get().borrowSpanView(spanInfos[i], span);
             container = view.getContainer();
             result = container.iadd(startLowBits, endExclusive);
             if (result.isAllOnes()) {
@@ -680,7 +680,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
             if (!RspArray.isFullBlockSpan(span)) { // if it is a full block span, we already have the range.
                 final Container result;
                 Container container = null;
-                try (SpanView view = workDataPerThread.get().borrowSpanView(this, pos, spanInfos[pos], span)) {
+                try (SpanView view = workDataPerThread.get().borrowSpanView(spanInfos[pos], span)) {
                     if (view.isSingletonSpan()) {
                         final long single = view.getSingletonSpanValue();
                         result = containerForLowValueAndRange(lowBitsAsInt(single), start, end);
@@ -847,7 +847,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
         if (RspArray.isFullBlockSpan(span)) {
             return true;
         }
-        try (SpanView view = workDataPerThread.get().borrowSpanView(this, i, spanInfos[i], span)) {
+        try (SpanView view = workDataPerThread.get().borrowSpanView(spanInfos[i], span)) {
             if (view.isSingletonSpan()) {
                 return view.getSingletonSpanValue() == val;
             }
@@ -892,7 +892,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
                     removeSpanAtIndex(i);
                 }
             } else {
-                try (SpanView view = workDataPerThread.get().borrowSpanView(this, i, spanInfo, s)) {
+                try (SpanView view = workDataPerThread.get().borrowSpanView(spanInfo, s)) {
                     final Container orig = view.getContainer();
                     final Container result = orig.iunset(lowBitsAsShort(val));
                     if (result.isSingleElement()) {
@@ -1429,7 +1429,7 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
                     final long v = spanInfoToSingletonSpanValue(spanInfo);
                     c = Container.singleton(lowBitsAsShort(v));
                 } else {
-                    view.init(this, i, spanInfo, span);
+                    view.init(spanInfo, span);
                     c = view.getContainer();
                 }
                 final RangeConsumer rc = (final int rs, final int re) -> {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspIterator.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspIterator.java
@@ -203,7 +203,7 @@ public class RspIterator implements PrimitiveIterator.OfLong, SafeCloseable {
             };
             return;
         }
-        sitView.init(p.arr(), p.arrIdx(), spanInfo, s);
+        sitView.init(spanInfo, s);
         final Container c = sitView.getContainer();
         final int intSkipCount = (int) (((long) Integer.MAX_VALUE) & skipCount);
         sit = new SingleSpanIterator() {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRangeBatchIterator.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRangeBatchIterator.java
@@ -60,7 +60,7 @@ public class RspRangeBatchIterator implements SafeCloseable {
             bufKey = spanInfoToKey(spanInfo);
             return;
         }
-        riView.init(p.arr(), p.arrIdx(), spanInfo, s);
+        riView.init(spanInfo, s);
         ri = riView.getContainer().getShortRangeIterator((int) ((long) (Integer.MAX_VALUE) & startOffset));
         bufKey = spanInfoToKey(spanInfo);
         if (!ri.hasNext()) {
@@ -252,7 +252,7 @@ public class RspRangeBatchIterator implements SafeCloseable {
                 riView.reset();
                 ri = new SingletonContainer.SearchRangeIter(lowBitsValue);
             } else {
-                riView.init(p.arr(), p.arrIdx(), spanInfo, s);
+                riView.init(spanInfo, s);
                 ri = riView.getContainer().getShortRangeIterator(0);
             }
         }

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRangeIterator.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRangeIterator.java
@@ -126,7 +126,7 @@ public class RspRangeIterator implements LongRangeIterator, SafeCloseable {
                 riView.reset();
                 ri = new SingletonContainer.SearchRangeIter(lowBits(singletonValue));
             } else {
-                riView.init(p.arr(), p.arrIdx(), spanInfo, s);
+                riView.init(spanInfo, s);
                 ri = riView.getContainer().getShortRangeIterator(0);
             }
             // ri.hasNext() has to be true by construction; this container can't be empty or it wouldn't be present.
@@ -148,7 +148,7 @@ public class RspRangeIterator implements LongRangeIterator, SafeCloseable {
         if (getFullBlockSpanLen(spanInfo, s) > 0) {
             return spanKey;
         }
-        try (SpanView res = workDataPerThread.get().borrowSpanView(p.arr(), p.arrIdx(), spanInfo, s)) {
+        try (SpanView res = workDataPerThread.get().borrowSpanView(spanInfo, s)) {
             return spanKey | (long) res.getContainer().first();
         }
     }

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspReverseIterator.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspReverseIterator.java
@@ -76,7 +76,7 @@ public class RspReverseIterator implements SafeCloseable {
             final long singletonValue = spanInfoToSingletonSpanValue(spanInfo);
             ri = new SingletonContainer.ReverseIter(lowBits(singletonValue));
         } else {
-            riView.init(rp.arr(), rp.arrIdx(), spanInfo, s);
+            riView.init(spanInfo, s);
             ri = riView.getContainer().getReverseShortIterator();
         }
         nextValid = true;
@@ -139,7 +139,7 @@ public class RspReverseIterator implements SafeCloseable {
         if (flen > 0) {
             current = key;
         } else {
-            try (SpanView res = workDataPerThread.get().borrowSpanView(rp.arr(), rp.arrIdx(), spanInfo, span)) {
+            try (SpanView res = workDataPerThread.get().borrowSpanView(spanInfo, span)) {
                 current = key | res.getContainer().first();
             }
         }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RspArrayConcurrentReaderSharedFlagTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RspArrayConcurrentReaderSharedFlagTest.java
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.rowset.impl;
+
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.rowset.impl.rsp.RspArray;
+import io.deephaven.test.types.OutOfBandTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * {@link RefCountedCow} lets readers run concurrently with the single writer of an unshared set, discarding results the
+ * clock invalidates. The derivation paths that share containers (deepCopy, the RspArray sub-range constructors, the
+ * shared-container appends) have to record that a packed ArrayContainer is now shared where the <em>source</em> will
+ * see it, and the source is the set being read, under mutation by its writer. The only thing a reader may write is the
+ * flag slot of the {@code short[]} it shares: never a word of the source, which may by then describe a different span,
+ * and which the writer may be updating at the same moment. The writer's set is live, and no retry would repair it.
+ *
+ * <p>
+ * The race is timing dependent, so the test keeps mutating for a fixed budget rather than a fixed number of passes; it
+ * reproduced within a few seconds on every run while the flag was a bit in the source's word.
+ */
+@Category(OutOfBandTest.class)
+public class RspArrayConcurrentReaderSharedFlagTest {
+    private static final long BS = RspArray.BLOCK_SIZE;
+    private static final int BLOCKS = 6000;
+
+    @Test
+    public void testReaderDerivingSubsetsDoesNotCorruptTheWriterSet() throws InterruptedException {
+        run(true, 6_000_000_000L);
+    }
+
+    /** Control: a reader that only takes and drops references never writes into the source. */
+    @Test
+    public void testReaderTakingReferencesOnlyDoesNotCorruptTheWriterSet() throws InterruptedException {
+        run(false, 1_000_000_000L);
+    }
+
+    private static void run(final boolean readerDerivesSubsets, final long budgetNanos) throws InterruptedException {
+        // One packed ArrayContainer (scattered values) per block, so every span's spanInfo carries cardinality bits.
+        final RowSetBuilderSequential b = RowSetFactory.builderSequential();
+        for (int i = 0; i < BLOCKS; ++i) {
+            final long base = (long) i * BS;
+            for (int j = 0; j < 8; ++j) {
+                b.appendKey(base + 3L * j + 1);
+            }
+        }
+        final WritableRowSet live = b.build();
+        final AtomicBoolean done = new AtomicBoolean(false);
+        final AtomicReference<Throwable> readerFailure = new AtomicReference<>();
+        final AtomicLong readerWork = new AtomicLong(); // keeps the reads from being optimized away
+        final Runnable readerLoop = () -> {
+            try {
+                while (!done.get()) {
+                    // A gap between snapshot attempts, as a real reader has between snapshots: it is what lets the
+                    // writer find its set unshared (and so mutate it in place) just before the next attempt begins.
+                    final long t0 = System.nanoTime();
+                    while (System.nanoTime() - t0 < 100_000) {
+                        Thread.onSpinWait();
+                    }
+                    // A snapshot-style read: take a reference to the current set, then derive a sub range from it.
+                    // Nothing the reader observes is checked: racing the writer, it may see torn sizes and keys, and
+                    // the contract only promises that it can discard such a result and retry. The test's assertions
+                    // are on the writer's set.
+                    try (final RowSet c = live.copy()) {
+                        if (readerDerivesSubsets) {
+                            try (final RowSet sub = c.subSetByKeyRange(1 + 1, Long.MAX_VALUE - 1)) {
+                                readerWork.addAndGet(sub.size());
+                            }
+                        } else {
+                            readerWork.addAndGet(c.size() + c.firstRowKey());
+                        }
+                    } catch (RuntimeException e) {
+                        // A torn read is allowed by the contract; the reader would retry.
+                    }
+                }
+            } catch (Throwable t) {
+                readerFailure.set(t);
+            }
+        };
+        final Thread reader = new Thread(readerLoop, "reader");
+        reader.setDaemon(true);
+        reader.start();
+        Throwable writerFailure = null;
+        long expectedSize = live.size();
+        try {
+            // Each pass adds one new value to every block, in place when the reader does not hold a reference.
+            final long deadline = System.nanoTime() + budgetNanos;
+            for (int pass = 0; System.nanoTime() < deadline && writerFailure == null; ++pass) {
+                final RowSetBuilderSequential add = RowSetFactory.builderSequential();
+                for (int i = 0; i < BLOCKS; ++i) {
+                    add.appendKey((long) i * BS + 100 + pass);
+                }
+                try (final RowSet toAdd = add.build()) {
+                    live.insert(toAdd);
+                    expectedSize += toAdd.size();
+                }
+                if (live.size() != expectedSize) {
+                    writerFailure = new AssertionError("pass " + pass + ": writer's set lost or gained keys: size="
+                            + live.size() + " expected=" + expectedSize);
+                    break;
+                }
+                if ((pass & 15) == 15) {
+                    try {
+                        live.validate("pass " + pass);
+                    } catch (RuntimeException | AssertionError e) {
+                        writerFailure = e;
+                    }
+                }
+            }
+        } finally {
+            done.set(true);
+            reader.join(10_000);
+        }
+        assertFalse("the reader did not stop within 10 seconds of being told to", reader.isAlive());
+        assertNull("writer's live set was corrupted by a concurrent reader: " + writerFailure, writerFailure);
+        assertNull("reader failed unexpectedly: " + readerFailure.get(), readerFailure.get());
+        live.close();
+    }
+}

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RspArrayConcurrentReaderSharedFlagTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/RspArrayConcurrentReaderSharedFlagTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * {@link RefCountedCow} lets readers run concurrently with the single writer of an unshared set, discarding results the
@@ -60,6 +61,7 @@ public class RspArrayConcurrentReaderSharedFlagTest {
         final AtomicBoolean done = new AtomicBoolean(false);
         final AtomicReference<Throwable> readerFailure = new AtomicReference<>();
         final AtomicLong readerWork = new AtomicLong(); // keeps the reads from being optimized away
+        final AtomicLong readerCompleted = new AtomicLong(); // derivations that ran to completion
         final Runnable readerLoop = () -> {
             try {
                 while (!done.get()) {
@@ -72,7 +74,8 @@ public class RspArrayConcurrentReaderSharedFlagTest {
                     // A snapshot-style read: take a reference to the current set, then derive a sub range from it.
                     // Nothing the reader observes is checked: racing the writer, it may see torn sizes and keys, and
                     // the contract only promises that it can discard such a result and retry. The test's assertions
-                    // are on the writer's set.
+                    // are on the writer's set, plus a count of derivations that ran to completion, so that a reader
+                    // failing on every attempt cannot make the test pass by never sharing anything.
                     try (final RowSet c = live.copy()) {
                         if (readerDerivesSubsets) {
                             try (final RowSet sub = c.subSetByKeyRange(1 + 1, Long.MAX_VALUE - 1)) {
@@ -81,6 +84,7 @@ public class RspArrayConcurrentReaderSharedFlagTest {
                         } else {
                             readerWork.addAndGet(c.size() + c.firstRowKey());
                         }
+                        readerCompleted.incrementAndGet();
                     } catch (RuntimeException e) {
                         // A torn read is allowed by the contract; the reader would retry.
                     }
@@ -126,6 +130,8 @@ public class RspArrayConcurrentReaderSharedFlagTest {
         assertFalse("the reader did not stop within 10 seconds of being told to", reader.isAlive());
         assertNull("writer's live set was corrupted by a concurrent reader: " + writerFailure, writerFailure);
         assertNull("reader failed unexpectedly: " + readerFailure.get(), readerFailure.get());
+        assertTrue("the reader never completed a derivation, so nothing was shared with the writer's set",
+                readerCompleted.get() > 0);
         live.close();
     }
 }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/WritableRowSetImplTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/WritableRowSetImplTest.java
@@ -3007,11 +3007,12 @@ public class WritableRowSetImplTest extends TestCase {
             if (block % 2 == 0) {
                 b.appendRange(blockKey + 11, blockKey + 20);
             } else {
+                // Five values: with the reserved slot, six shorts fill the 24 bytes the allocator rounds the array
+                // to, so a compact container has nothing to spare.
                 b.appendKey(blockKey + 12);
                 b.appendKey(blockKey + 14);
                 b.appendKey(blockKey + 16);
                 b.appendKey(blockKey + 18);
-                b.appendKey(blockKey + 20);
             }
         }
         final OrderedLongSet impl = b.getOrderedLongSet();

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapContainerSharingTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapContainerSharingTest.java
@@ -3,26 +3,30 @@
 //
 package io.deephaven.engine.rowset.impl.rsp;
 
+import io.deephaven.engine.rowset.impl.rsp.container.ArrayContainer;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_SIZE;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Two RspBitmaps may share a container copy-on-write. A packed ArrayContainer keeps its shared flag in the owning
- * array's spanInfo word rather than on the container, so both sides have to be marked when such a container becomes
- * shared: a side whose flag is clear edits the shared {@code short[]} in place and silently changes the other side.
+ * Two RspBitmaps may share a container copy-on-write. A packed ArrayContainer is a bare {@code short[]} with no
+ * container object to carry a flag, so its shared flag lives in the array's reserved last slot, where every holder of
+ * the array sees it: a side that missed the flag would edit the shared {@code short[]} in place and silently change the
+ * other side. The spanInfo word of a packed span holds only its key and cardinality.
  */
 public class RspBitmapContainerSharingTest {
 
     private static final long BS = BLOCK_SIZE;
-    private static final long SHARED_BIT = 1L << 15;
 
     private static List<Long> valuesOf(final RspBitmap rb) {
         final List<Long> keys = new ArrayList<>();
@@ -68,21 +72,109 @@ public class RspBitmapContainerSharingTest {
         assertEquals("andNot result changed when its input was mutated afterwards", expected, valuesOf(result));
     }
 
-    /** Sharing a packed container through the span-index constructor must mark both sides. */
+    /**
+     * Sharing a packed container through the span-index constructor marks the shared array, which both sides read, and
+     * leaves both words as plain key and cardinality.
+     */
     @Test
-    public void testSpanIndexConstructorMarksBothSidesShared() {
+    public void testSpanIndexConstructorMarksTheSharedArray() {
         final RspBitmap r1 = withPackedArrayContainer();
         assertTrue("precondition: span 1 is a packed ArrayContainer", r1.spans[1] instanceof short[]);
-        assertEquals("precondition: it starts out unshared", 0L, r1.spanInfos[1] & SHARED_BIT);
+        final short[] packed = (short[]) r1.spans[1];
+        assertFalse("precondition: it starts out unshared", ArrayContainer.isContentShared(packed));
+        assertEquals("the word is the key and the cardinality", BS | 5, r1.spanInfos[1]);
 
         final RspBitmap sub = new RspBitmap(r1, 1, 1);
-        assertSame("the short[] is expected to be shared, not copied", r1.spans[1], sub.spans[0]);
-        assertNotEquals("the copy must be marked shared", 0L, sub.spanInfos[0] & SHARED_BIT);
-        assertNotEquals("the source must be marked shared too, or it will edit the shared short[] in place",
-                0L, r1.spanInfos[1] & SHARED_BIT);
+        assertSame("the short[] is expected to be shared, not copied", packed, sub.spans[0]);
+        assertTrue("the shared array must be marked, or the source will edit it in place",
+                ArrayContainer.isContentShared(packed));
+        assertEquals("the source's word is unchanged by sharing", BS | 5, r1.spanInfos[1]);
+        assertEquals("the copy's word is the key and the cardinality", BS | 5, sub.spanInfos[0]);
     }
 
-    /** The other direction: mutating the copy must leave the source alone. */
+    /**
+     * A sub range that covers a whole block shares that block's packed container rather than copying it, through the
+     * shared-container append path. The copy's word has to carry the container's cardinality, not just its key, or the
+     * copy reads the container as empty.
+     */
+    @Test
+    public void testSubrangeCoveringAWholeBlockSharesThePackedContainer() {
+        final RspBitmap r1 = withPackedArrayContainer();
+        final short[] packed = (short[]) r1.spans[1];
+
+        final RspBitmap sub = r1.subrangeByValue(BS, 2 * BS - 1, true);
+        assertEquals(List.of(BS + 2, BS + 4, BS + 6, BS + 9, BS + 12), valuesOf(sub));
+        assertSame("the whole block is shared, not copied", packed, sub.spans[0]);
+        assertEquals("the copy's word is the key and the cardinality", BS | 5, sub.spanInfos[0]);
+        assertEquals("the source's word is unchanged", BS | 5, r1.spanInfos[1]);
+        assertTrue(ArrayContainer.isContentShared(packed));
+        sub.validate("sub range sharing a packed container");
+        r1.validate("source after a sub range shared its packed container");
+    }
+
+    /**
+     * The marking protocol: a reader that shares a packed container marks the array it observed, and nothing else in
+     * the source. Here the reader is late: by the time it marks, the owner has replaced the span, and in a way that
+     * would have defeated a check on the word. The span had cardinality 4 and is replaced by a singleton whose low bits
+     * are also 4, so the two words are equal; a flag written into the word would have turned the singleton into a
+     * different key. Written into the orphaned array instead, the mark reaches nothing the owner still holds.
+     */
+    @Test
+    public void testLateMarkOfAReplacedSpanLeavesTheOwnerAlone() {
+        RspBitmap r1 = new RspBitmap();
+        r1 = r1.add(10);
+        r1 = r1.add(BS + 1);
+        r1 = r1.add(BS + 4);
+        r1 = r1.add(BS + 7);
+        r1 = r1.add(BS + 9);
+        assertTrue("precondition: span 1 is a packed ArrayContainer", r1.spans[1] instanceof short[]);
+        assertEquals("precondition: the span's word is key | 4", BS | 4, r1.spanInfos[1]);
+        // What a reader deriving from r1 observes before it gets around to marking.
+        final short[] observed = (short[]) r1.spans[1];
+
+        // The owner replaces the span with the singleton BS + 4, whose word is also BS | 4.
+        r1 = r1.remove(BS + 1);
+        r1 = r1.remove(BS + 7);
+        r1 = r1.remove(BS + 9);
+        assertEquals(List.of(10L, BS + 4), valuesOf(r1));
+        assertNull("the block is now a singleton span", r1.spans[1]);
+        assertEquals("the singleton's word coincides with the packed span's", BS | 4, r1.spanInfos[1]);
+        final long[] wordsBefore = r1.spanInfos.clone();
+        final Object[] spansBefore = r1.spans.clone();
+
+        // The late reader marks what it observed.
+        ArrayContainer.markContentShared(observed);
+
+        assertArrayEquals("the owner's words are untouched", wordsBefore, r1.spanInfos);
+        assertArrayEquals("the owner's spans are untouched", spansBefore, r1.spans);
+        assertEquals(List.of(10L, BS + 4), valuesOf(r1));
+        r1.validate("owner after a late mark of a span it had replaced");
+        assertTrue("the orphaned array carries the mark", ArrayContainer.isContentShared(observed));
+    }
+
+    /**
+     * The other half of the protocol: when the reader is not late, the owner finds the flag on the array it is about to
+     * edit and copies instead. The reader here is a bare mark with no RspBitmap of its own, which is all the owner ever
+     * sees of one.
+     */
+    @Test
+    public void testOwnerCopiesOnWriteOnceAReaderHasMarkedItsSpan() {
+        RspBitmap r1 = withPackedArrayContainer();
+        final short[] observed = (short[]) r1.spans[1];
+
+        ArrayContainer.markContentShared(observed);
+        final short[] observedContents = observed.clone();
+
+        r1 = r1.remove(BS + 4);
+        assertEquals(List.of(10L, BS + 2, BS + 6, BS + 9, BS + 12), valuesOf(r1));
+        assertNotSame("the owner must have copied rather than edited the marked array", observed, r1.spans[1]);
+        assertArrayEquals("the marked array is unchanged", observedContents, observed);
+        assertEquals("the owner's new word is the key and the cardinality", BS | 4, r1.spanInfos[1]);
+        assertTrue("the owner's new array is its own", r1.spans[1] instanceof short[]);
+        assertFalse(ArrayContainer.isContentShared((short[]) r1.spans[1]));
+        r1.validate("owner after copying a marked span on write");
+    }
+
     /**
      * The same constructor also has to cope with a full block span too long to be held by the marker form. Beyond
      * 0xFFFF blocks the span object is a boxed Long, which is no more a container than the marker is.


### PR DESCRIPTION
Fixes DH-23579.

When an `RspArray` starts sharing a packed `ArrayContainer` span (a bare `short[]`) with a source array, it has to mark the *source's* copy as shared, or the source keeps editing the `short[]` in place and silently changes the sharer. Until now that flag was bit 15 of the source's `spanInfos` word, so a reader deriving from a live rowset wrote into a word it did not own. `RefCountedCow` lets that reader run while the single owner mutates the array in place; the reader's own result is discarded once the clock shows it stale, but a stale word written back over the owner's concurrent update was permanent, and keys vanished from the live set. No way of writing the word from the reader is fully safe: by the time it writes, the index may describe a different span whose word happens to coincide.

This change moves the flag out of the word and into the array itself. Every `ArrayContainer` content array now reserves its last element, which never holds a value; a container's capacity is `content.length - 1`, and the shared flag is bit 0 of that slot. Marking a packed container shared is a write to the `short[]` the reader holds and to nothing else: if the owner has since replaced the span, the array is orphaned and the write is harmless, and if not, the owner sees the flag on the very array it is about to edit. The flag is only ever set, never cleared, so two readers racing each other are fine too, and the owner's in-place value writes never touch the slot. The `spanInfos` word of a packed span is now `key | cardinality` at all times.

* `ArrayContainer`: `capacity()` replaces `content.length` in every growth and compaction decision; all allocation goes through `newContent(capacity)`, which adds the slot before the 8-byte rounding; `DEFAULT_MAX_SIZE` drops by one so the largest array still fits exactly in a bitmap's 8192 bytes; the `shared` field is gone and `isShared()`/`setCopyOnWrite()` read and write the slot; `makeByWrapping` and the protected constructor reject arrays with no room for the slot; the one-argument `ArrayContainer(short[])` constructor copies instead of wrapping.
* `RspArray`: the four marking sites (`setSharedContainerMaybePackedRaw`, `copyKeyAndSpanMaybeSharing`, the sub-range constructor, and `SpanView.setCopyOnWrite`) mark the array; `SpanView` no longer keeps a back reference to its array; `validate` checks that packed arrays have the reserved slot; `containerOverhead` and the memory stats don't count the slot as spare capacity.
* Tests: `RspArrayConcurrentReaderSharedFlagTest` (out of band) is the stress test from the ticket, which lost keys within 40 ms on `main` and now runs its six second budget clean; `RspBitmapContainerSharingTest` gains deterministic tests of the marking protocol, including the word-coincidence case from the ticket (a cardinality-4 span replaced by a singleton whose low bits are 4); `TestArrayContainer` covers the slot invariants.

Packing `RunContainer`s the same way was considered and deliberately left out; the analysis is in a comment on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQjWkEHyWr9TbzEtJAa7Lk
