### PR TITLE
fix: DH-23627: Allow writing an empty table with an explicit RowGroupInfo

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/RowGroupTableIteratorVisitor.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/RowGroupTableIteratorVisitor.java
@@ -23,7 +23,8 @@ final class RowGroupTableIteratorVisitor implements RowGroupInfo.Visitor<Iterato
     }
 
     private static Iterator<Table> splitByMaxRows(final Table input, final long maxRows) {
-        if (maxRows == Long.MAX_VALUE) {
+        // An empty input would compute zero RowGroups below; emit it as a single RowGroup, as SingleGroup does
+        if (maxRows == Long.MAX_VALUE || input.isEmpty()) {
             return List.of(input).iterator();
         }
         final long numRowGroups = (input.size() / maxRows) + ((input.size() % maxRows) > 0 ? 1 : 0);
@@ -32,7 +33,8 @@ final class RowGroupTableIteratorVisitor implements RowGroupInfo.Visitor<Iterato
 
     private static Iterator<Table> splitByMaxGroups(final Table table, final long numGroups) {
         if (numGroups < 1) {
-            throw new IllegalArgumentException("Number of groups must be at least 1, got: " + numGroups);
+            // Unreachable: RowGroupInfo validates its arguments, and splitByMaxRows handles the empty input
+            throw new IllegalStateException("Number of groups must be at least 1, got: " + numGroups);
         } else if (numGroups == 1) {
             return List.of(table).iterator();
         }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -349,6 +349,53 @@ public final class ParquetTableReadWriteTest {
         assertEquals(t.getDefinition(), fromDisk.getDefinition());
     }
 
+    /**
+     * DH-23627: writing an empty table must succeed for every {@link RowGroupInfo}; {@code maxRows} used to fail.
+     */
+    @Test
+    public void emptyTableWithRowGroupInfo() {
+        final Table t = newTable(intCol("Value"), stringCol("Key"));
+        final List<RowGroupInfo> rowGroupInfos = List.of(
+                RowGroupInfo.singleGroup(),
+                RowGroupInfo.maxRows(3),
+                RowGroupInfo.maxGroups(4),
+                RowGroupInfo.byGroups("Key"),
+                RowGroupInfo.byGroups(3, "Key"));
+
+        for (int ii = 0; ii < rowGroupInfos.size(); ii++) {
+            final RowGroupInfo rowGroupInfo = rowGroupInfos.get(ii);
+            final File dest = new File(rootFile, "ParquetTest_emptyRowGroupInfo_" + ii + "_test.parquet");
+            writeTable(t, dest.getPath(),
+                    new ParquetInstructions.Builder().setRowGroupInfo(rowGroupInfo).build());
+            final Table fromDisk = checkSingleTable(t, dest);
+            assertEquals(rowGroupInfo.toString(), t.getDefinition(), fromDisk.getDefinition());
+            assertEquals(rowGroupInfo.toString(), 0, fromDisk.size());
+        }
+    }
+
+    /**
+     * DH-23627 as originally reported: an empty table written beside populated ones in a flat-partitioned layout.
+     */
+    @Test
+    public void emptyTableBesidePopulatedTablesWithRowGroupInfo() {
+        final File destDir = new File(rootFile, "ParquetTest_emptyBesidePopulated_test");
+        assertTrue(destDir.mkdirs());
+        final ParquetInstructions instructions =
+                new ParquetInstructions.Builder().setRowGroupInfo(RowGroupInfo.maxRows(3)).build();
+
+        final Table first = newTable(intCol("Value", 1, 2, 3, 4, 5), stringCol("Key", "a", "a", "b", "b", "c"));
+        final Table empty = newTable(intCol("Value"), stringCol("Key"));
+        final Table last = newTable(intCol("Value", 6, 7), stringCol("Key", "d", "d"));
+
+        writeTable(first, new File(destDir, "table_00000.parquet").getPath(), instructions);
+        writeTable(empty, new File(destDir, "table_00001.parquet").getPath(), instructions);
+        writeTable(last, new File(destDir, "table_00002.parquet").getPath(), instructions);
+
+        final Table fromDisk = readTable(destDir.getPath(),
+                EMPTY.withLayout(ParquetInstructions.ParquetFileLayout.FLAT_PARTITIONED));
+        assertTableEquals(merge(first, last), fromDisk);
+    }
+
     @Test
     public void flatParquetFormat() {
         flatTable("emptyFlatParquet", 0, true);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestRowGroupTableIteratorVisitor.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestRowGroupTableIteratorVisitor.java
@@ -74,7 +74,9 @@ public class TestRowGroupTableIteratorVisitor {
     private static List<Table> getRowGroups(final @NotNull Table input, final @NotNull RowGroupInfo rgi) {
         final List<Table> rowGroups = new ArrayList<>();
         RowGroupTableIteratorVisitor.of(rgi, input).forEachRemaining(rowGroups::add);
-        assertEquals("Sum of RowGroups equals Table.size()", input.size(), merge(rowGroups).size());
+        // `merge` rejects an empty list
+        final long totalRows = rowGroups.isEmpty() ? 0 : merge(rowGroups).size();
+        assertEquals("Sum of RowGroups equals Table.size()", input.size(), totalRows);
         return rowGroups;
     }
 
@@ -245,6 +247,32 @@ public class TestRowGroupTableIteratorVisitor {
 
         assertDistinctValues(rowGroups, groupCol);
         assertRowGroupSizes(rowGroups, maxRows);
+    }
+
+    /**
+     * DH-23627: every {@link RowGroupInfo} must accept an empty table; {@code maxRows} used to throw. The number of
+     * RowGroups produced is immaterial, since the writer skips zero-row RowGroups.
+     */
+    @Test
+    public void testEmptyTable() {
+        final Table emptyTable = TableTools.newTable(TableTools.intCol("Value"), TableTools.stringCol("Key"));
+
+        // `maxRows` behaves as `singleGroup` does
+        final List<Table> maxRowsGroups = getRowGroups(emptyTable, RowGroupInfo.maxRows(3));
+        assertEquals("maxRows(3) returns a single RowGroup", 1, maxRowsGroups.size());
+        assertTrue("the single RowGroup is empty", maxRowsGroups.get(0).isEmpty());
+
+        final List<Table> singleGroups = getRowGroups(emptyTable, RowGroupInfo.singleGroup());
+        assertEquals("singleGroup() returns a single RowGroup", 1, singleGroups.size());
+        assertTrue("the single RowGroup is empty", singleGroups.get(0).isEmpty());
+
+        // `maxGroups` and `byGroups` define no RowGroups at all
+        assertEquals("maxGroups(4) returns no RowGroups", 0,
+                getRowGroups(emptyTable, RowGroupInfo.maxGroups(4)).size());
+        assertEquals("byGroups(Key) returns no RowGroups", 0,
+                getRowGroups(emptyTable, RowGroupInfo.byGroups("Key")).size());
+        assertEquals("byGroups(3, Key) returns no RowGroups", 0,
+                getRowGroups(emptyTable, RowGroupInfo.byGroups(3, "Key")).size());
     }
 
     /**


### PR DESCRIPTION
Writing a zero-row table with `RowGroupInfo.maxRows(n)` failed with
`Number of groups must be at least 1, got: 0`. The row-group count derived
from `size / maxRows` was zero, which the downstream `maxGroups` check rejected.
The other `RowGroupInfo` settings already handled empty input.

`splitByMaxRows` now short-circuits an empty input and emits it as a single
RowGroup, matching `singleGroup`. Since `byGroups` delegates to `splitByMaxRows`
per partition, it is covered by the same guard. The writer already skips zero-row
RowGroups, so every setting produces the same valid file with no RowGroups.

With `RowGroupInfo` validating its own arguments and the empty case handled, the
`numGroups < 1` branch in `splitByMaxGroups` is an internal invariant rather than
an input check, so it now throws `IllegalStateException`.

Tests cover the visitor in isolation for each setting on an empty table, the
end-to-end write and read-back for each setting, and the originally reported
shape: an empty table written beside populated ones in a flat-partitioned layout.