### PR TITLE
fix: DH-23389: Update grpc-web-gwt-fetch to 1.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ netty = "4.1.137.Final"
 protobuf-gwt='4.33.2-2'
 grpc-gwt='1.76.2-2'
 
-grpc-web-gwt-fetch='1.3.0'
+grpc-web-gwt-fetch='1.4.0'
 
 guava = "33.7.1-jre"
 gwt = "2.13.1"

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/AuthenticationInterceptor.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/AuthenticationInterceptor.java
@@ -78,7 +78,7 @@ public class AuthenticationInterceptor implements ClientInterceptor {
      * Handles the response info from the server, returning a context to signal if a session was created as a result or
      * not.
      */
-    private Context handleMetadata(@Nullable Status status, Metadata metadata) {
+    private Context handleMetadata(@Nullable Status status, @Nullable Metadata metadata) {
         // metadata may be null when a stream closes before any headers/trailers arrive
         String authHeader = metadata == null ? null : metadata.get(AUTHORIZATION_HEADER);
         if (authHeader == null && status == null) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/AuthenticationInterceptor.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/AuthenticationInterceptor.java
@@ -79,7 +79,8 @@ public class AuthenticationInterceptor implements ClientInterceptor {
      * not.
      */
     private Context handleMetadata(@Nullable Status status, Metadata metadata) {
-        String authHeader = metadata.get(AUTHORIZATION_HEADER);
+        // metadata may be null when a stream closes before any headers/trailers arrive
+        String authHeader = metadata == null ? null : metadata.get(AUTHORIZATION_HEADER);
         if (authHeader == null && status == null) {
             // No useful response, ignore - probably looking at initial headers.
             return Context.current();


### PR DESCRIPTION
When a gRPC stream closes without well-formed headers/trailers (e.g. a disconnect),
dh-core.js threw `TypeError: can't access property "size_0", this$static is undefined`.

- Bump grpc-web-gwt-fetch 1.3.0 -> 1.4.0, which null-guards `getStatus` in the fetch
  transport (`AbstractGrpcWebChannel`) when trailers metadata is null.
- Null-check the trailers `Metadata` in `AuthenticationInterceptor.handleMetadata`,
  which the transport still passes as null to `onClose` on such closes.

Deployed and tested on my BHS `vlad-DH-20757`