### PR TITLE
perf: DH-23630: Skip the SortedRanges insert pre-pass when it cannot pay for itself

### DIFF
--- a/engine/benchmark/build.gradle
+++ b/engine/benchmark/build.gradle
@@ -75,6 +75,8 @@ createJmhTask('jmhRunMatchHistorical',
         ['MatchFilterHistoricalBenchmark',
          '-prof=io.deephaven.benchmark.db.ResultSizeProfiler'])
 createJmhTask('jmhRunRowSetGetFind', 'RowSetGetFindBench', ['-DMetricsManager.enabled=true'])
+createJmhTask('jmhRunRowSetIncrementalInsert', 'RowSetIncrementalInsertBench')
+createJmhTask('jmhRunRspSortedRangesInsertShape', 'RspSortedRangesInsertShapeBench')
 
 def createDeephavenTestExecTask = {
     taskName, mainClass -> tasks.create(taskName, JavaExec, { JavaExec task ->

--- a/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RowSetIncrementalInsertBench.java
+++ b/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RowSetIncrementalInsertBench.java
@@ -1,0 +1,184 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.benchmark.engine.util;
+
+import io.deephaven.benchmarking.BenchUtil;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.rowset.impl.OrderedLongSet;
+import io.deephaven.engine.rowset.impl.WritableRowSetImpl;
+import io.deephaven.engine.rowset.impl.rsp.RspBitmap;
+import io.deephaven.engine.rowset.impl.sortedranges.SortedRanges;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * One update cycle of a bucketed, ticking {@code updateBy}, reduced to the row set work it does per bucket.
+ *
+ * <p>
+ * Each cycle a contiguous run of {@code addedPerCycle} rows arrives at the top of a {@code rows}-key table. Rows are
+ * dealt round robin across {@code buckets} buckets, so a bucket's rows are single keys spaced {@code buckets} apart,
+ * and each dirty bucket reports the added rows it received plus the {@code windowRows} rows before them as a small row
+ * set: a {@link SortedRanges} when there are many buckets, an {@link RspBitmap} when there are few and each bucket's
+ * rows are dense. {@code updateBy} accumulates those per-bucket sets into one row set (the modified rows, and the rows
+ * each input source must supply), so the accumulator sees one small insert per dirty bucket: an {@link RspBitmap} once
+ * it outgrows {@link SortedRanges}, and every insert lands well below its last block.
+ *
+ * <p>
+ * {@link #rspIxInsert} is the current {@link RspBitmap#ixInsert} path, which for a {@link SortedRanges} runs a pre-pass
+ * over the incoming ranges before adding them; {@link #rspAddRangesDirect} is the body that
+ * {@code insertOrderedLongSetUnsafeNoWriteCheck} had before DH-23407, adding the ranges directly. The two do the same
+ * thing for an {@link RspBitmap} bucket. {@link #rowSetApiInsert} is the same work through the {@link WritableRowSet}
+ * API, including the accumulator's growth from a single range through {@link SortedRanges} into an {@link RspBitmap},
+ * so it can be run unchanged against builds on either side of the change.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@Fork(value = 1)
+public class RowSetIncrementalInsertBench {
+
+    private static final long RANDOM_SEED = 1;
+
+    /** Distinct bucket-key combinations; the 1, 2 and 3 group scales of the nightly updateBy benchmarks. */
+    @Param({"100", "10000", "100000"})
+    private int buckets;
+
+    /** Key space of the source table. */
+    @Param({"10000000"})
+    private long rows;
+
+    /** Rows the incremental release filter lets through per cycle. */
+    @Param({"100000"})
+    private int addedPerCycle;
+
+    /** Rows before the added ones that each dirty bucket needs, e.g. the reverse window of a rolling operation. */
+    @Param({"50"})
+    private int windowRows;
+
+    private long frontier;
+    private OrderedLongSet[] bucketAffectedSets;
+    private WritableRowSet[] bucketAffectedRowSets;
+
+    @Setup
+    public void setup() {
+        frontier = rows - addedPerCycle;
+        final long windowStart = Math.max(0, frontier - (long) windowRows * buckets);
+        bucketAffectedSets = new OrderedLongSet[buckets];
+        bucketAffectedRowSets = new WritableRowSet[buckets];
+        long totalKeys = 0;
+        for (int bucket = 0; bucket < buckets; ++bucket) {
+            final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+            long key = windowStart + Math.floorMod(bucket - windowStart, (long) buckets);
+            for (; key < rows; key += buckets) {
+                builder.appendKey(key);
+                ++totalKeys;
+            }
+            final WritableRowSet affected = builder.build();
+            bucketAffectedRowSets[bucket] = affected;
+            bucketAffectedSets[bucket] = ((WritableRowSetImpl) affected).getInnerSet();
+        }
+        // Buckets go dirty in an order unrelated to their keys.
+        final Random random = new Random(RANDOM_SEED);
+        for (int i = buckets - 1; i > 0; --i) {
+            final int j = random.nextInt(i + 1);
+            final OrderedLongSet set = bucketAffectedSets[i];
+            bucketAffectedSets[i] = bucketAffectedSets[j];
+            bucketAffectedSets[j] = set;
+            final WritableRowSet rs = bucketAffectedRowSets[i];
+            bucketAffectedRowSets[i] = bucketAffectedRowSets[j];
+            bucketAffectedRowSets[j] = rs;
+        }
+        System.out.println("buckets=" + buckets + " keysPerBucket=" + (totalKeys / buckets)
+                + " keysInsertedPerCycle=" + totalKeys
+                + " bucketSetType=" + bucketAffectedSets[0].getClass().getSimpleName());
+        describeWorkload();
+    }
+
+    /**
+     * Report the shape the searches see over one cycle: how long the accumulator's spans array gets, how many ranges
+     * each per-bucket set brings, and how often a range lands in the same block as the range before it.
+     */
+    private void describeWorkload() {
+        long ranges = 0;
+        long rangesInSameBlockAsPrevious = 0;
+        int maxSpans = 0;
+        RspBitmap accumulator = new RspBitmap(frontier, rows - 1);
+        for (final OrderedLongSet affected : bucketAffectedSets) {
+            long previousBlock = -1;
+            try (final io.deephaven.engine.rowset.RowSet.RangeIterator it = affected.ixRangeIterator()) {
+                while (it.hasNext()) {
+                    it.next();
+                    final long block = it.currentRangeStart() >> 16;
+                    ++ranges;
+                    if (block == previousBlock) {
+                        ++rangesInSameBlockAsPrevious;
+                    }
+                    previousBlock = block;
+                }
+            }
+            accumulator = accumulator.ixInsert(affected);
+            maxSpans = Math.max(maxSpans, accumulator.size());
+        }
+        System.out.println("rangesPerBucketSet=" + (ranges / buckets)
+                + " rangesInSameBlockAsPrevious=" + (100 * rangesInSameBlockAsPrevious / ranges) + "%"
+                + " accumulatorSpansMax=" + maxSpans + " accumulatorSpansFinal=" + accumulator.size()
+                + " accumulatorBlocks=" + ((rows - 1) / RspBitmap.BLOCK_SIZE
+                        - (frontier - (long) windowRows * buckets) / RspBitmap.BLOCK_SIZE + 1));
+    }
+
+    @Benchmark
+    public long rowSetApiInsert() {
+        try (final WritableRowSet accumulator = RowSetFactory.fromRange(frontier, rows - 1)) {
+            for (final WritableRowSet affected : bucketAffectedRowSets) {
+                accumulator.insert(affected);
+            }
+            return accumulator.size();
+        }
+    }
+
+    @Benchmark
+    public long rspIxInsert() {
+        RspBitmap accumulator = new RspBitmap(frontier, rows - 1);
+        for (final OrderedLongSet affected : bucketAffectedSets) {
+            accumulator = accumulator.ixInsert(affected);
+        }
+        return accumulator.getCardinality();
+    }
+
+    @Benchmark
+    public long rspAddRangesDirect() {
+        RspBitmap accumulator = new RspBitmap(frontier, rows - 1);
+        for (final OrderedLongSet affected : bucketAffectedSets) {
+            if (!(affected instanceof SortedRanges)) {
+                accumulator = accumulator.ixInsert(affected);
+                continue;
+            }
+            accumulator = accumulator.getWriteRef();
+            accumulator.addRangesUnsafeNoWriteCheck(((SortedRanges) affected).getRangeIterator());
+            accumulator.finishMutations();
+        }
+        return accumulator.getCardinality();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchUtil.run(RowSetIncrementalInsertBench.class);
+    }
+}

--- a/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RspSortedRangesInsertShapeBench.java
+++ b/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RspSortedRangesInsertShapeBench.java
@@ -109,25 +109,26 @@ public class RspSortedRangesInsertShapeBench {
     }
 
     // Neither insert finishes its mutations: rebuilding the cardinality cache costs the same on both paths and, being
-    // linear in the span count, would swamp a small insert into a long array.
+    // linear in the span count, would swamp a small insert into a long array. Each method returns the bitmap it
+    // mutated so that every update to it, including those inside existing spans, is observable.
 
     @Benchmark
-    public int copyOnly() {
-        return target.deepCopy().size();
+    public RspBitmap copyOnly() {
+        return target.deepCopy();
     }
 
     @Benchmark
-    public int prePassInsert() {
+    public RspBitmap prePassInsert() {
         final RspBitmap copy = target.deepCopy();
         copy.insertOrderedLongSetUnsafeNoWriteCheck(incoming);
-        return copy.size();
+        return copy;
     }
 
     @Benchmark
-    public int addRangesDirect() {
+    public RspBitmap addRangesDirect() {
         final RspBitmap copy = target.deepCopy();
         copy.addRangesUnsafeNoWriteCheck(incoming.getRangeIterator());
-        return copy.size();
+        return copy;
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RspSortedRangesInsertShapeBench.java
+++ b/engine/benchmark/src/main/java/io/deephaven/benchmark/engine/util/RspSortedRangesInsertShapeBench.java
@@ -1,0 +1,136 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.benchmark.engine.util;
+
+import io.deephaven.benchmarking.BenchUtil;
+import io.deephaven.engine.rowset.impl.rsp.RspBitmap;
+import io.deephaven.engine.rowset.impl.sortedranges.SortedRanges;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Inserting one {@link SortedRanges} into an {@link RspBitmap}, across the shapes that decide whether the pre-pass in
+ * {@code RspBitmap.insertOrderedLongSetUnsafeNoWriteCheck(SortedRanges)} pays for itself.
+ *
+ * <p>
+ * The target holds {@code spans} singleton spans, one in every other block, so the blocks between them are free. The
+ * incoming set holds {@code ranges} single keys spread evenly over the target's key range, {@code newSpanPercent} of
+ * them in free blocks. A key in a free block makes the insert create a span, which without the pre-pass means shifting
+ * the tail of the spans array; a key in an occupied block updates that span in place. With more ranges than spans the
+ * ranges share blocks, several to a block, and the free-or-occupied choice is made per block.
+ *
+ * <p>
+ * {@link #ixInsert} is the current path with the pre-pass; {@link #addRangesDirect} is the body that method had before
+ * DH-23407. Both start from a fresh copy of the target, and {@link #copyOnly} measures that copy alone so it can be
+ * subtracted.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(value = 1)
+public class RspSortedRangesInsertShapeBench {
+
+    /** Spans in the target's array before the insert. */
+    @Param({"32", "128", "512", "2048", "8192"})
+    private int spans;
+
+    /** Single-key ranges in the incoming set. */
+    @Param({"32", "1024"})
+    private int ranges;
+
+    /**
+     * Percentage of the incoming ranges (or of the blocks they share) that fall in blocks the target has no span for.
+     */
+    @Param({"0", "10", "100"})
+    private int newSpanPercent;
+
+    private RspBitmap target;
+    private SortedRanges incoming;
+
+    @Setup
+    public void setup() {
+        target = new RspBitmap();
+        for (int j = 0; j < spans; ++j) {
+            target = target.add(occupiedBlockKey(j));
+        }
+        SortedRanges sr = SortedRanges.makeEmpty();
+        int newSpans = 0;
+        long lastBlock = -1;
+        for (int r = 0; r < ranges; ++r) {
+            // The block pair this range goes to, ascending in r; and the ordinal that decides free or occupied, which
+            // is the range itself when every range has its own pair and the pair when they share it.
+            final int pair = (int) ((long) r * spans / ranges);
+            final int ordinal = ranges <= spans ? r : pair;
+            final boolean free = (long) (ordinal + 1) * newSpanPercent / 100 > (long) ordinal * newSpanPercent / 100;
+            final long blockKey = free ? occupiedBlockKey(pair) + RspBitmap.BLOCK_SIZE : occupiedBlockKey(pair);
+            if (free && blockKey != lastBlock) {
+                ++newSpans;
+            }
+            lastBlock = blockKey;
+            // Low bits ascend with r, so keys sharing a block stay in order, and by two so they stay separate ranges;
+            // starting at 1 keeps clear of the target's singleton.
+            sr = sr.append(blockKey + 1 + 2 * (r % (RspBitmap.BLOCK_SIZE / 2 - 1)));
+            if (sr == null) {
+                throw new IllegalStateException("incoming set does not fit in a SortedRanges");
+            }
+        }
+        incoming = sr;
+        int rangeCount = 0;
+        try (final io.deephaven.engine.rowset.RowSet.RangeIterator it = sr.getRangeIterator()) {
+            while (it.hasNext()) {
+                it.next();
+                ++rangeCount;
+            }
+        }
+        if (rangeCount != ranges) {
+            throw new IllegalStateException("incoming set has " + rangeCount + " ranges, expected " + ranges);
+        }
+        System.out.println("spans=" + spans + " ranges=" + ranges + " newSpanPercent=" + newSpanPercent
+                + " newSpans=" + newSpans + " incomingType=" + sr.getClass().getSimpleName());
+    }
+
+    private static long occupiedBlockKey(final int pair) {
+        return 2L * pair * RspBitmap.BLOCK_SIZE;
+    }
+
+    // Neither insert finishes its mutations: rebuilding the cardinality cache costs the same on both paths and, being
+    // linear in the span count, would swamp a small insert into a long array.
+
+    @Benchmark
+    public int copyOnly() {
+        return target.deepCopy().size();
+    }
+
+    @Benchmark
+    public int prePassInsert() {
+        final RspBitmap copy = target.deepCopy();
+        copy.insertOrderedLongSetUnsafeNoWriteCheck(incoming);
+        return copy.size();
+    }
+
+    @Benchmark
+    public int addRangesDirect() {
+        final RspBitmap copy = target.deepCopy();
+        copy.addRangesUnsafeNoWriteCheck(incoming.getRangeIterator());
+        return copy.size();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchUtil.run(RspSortedRangesInsertShapeBench.class);
+    }
+}

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
@@ -1432,7 +1432,37 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
         if (endPosExclusive == 0 || getKey(endPosExclusive - 1) == blockKey) {
             return endPosExclusive - 1;
         }
+        if (startPos < endPosExclusive && getKey(startPos) == blockKey) {
+            // Callers walking ascending keys start from the span they last found, and the next key is often in it.
+            return startPos;
+        }
         return unsignedBinarySearch(this::getKey, startPos, endPosExclusive, blockKey);
+    }
+
+    /**
+     * Whether every block from {@code firstKey}'s through {@code lastKey}'s has a span here.
+     *
+     * <p>
+     * Spans start in distinct, ascending blocks and each covers at least one block, so once the spans holding the two
+     * end blocks are found, the spans between them start in distinct blocks strictly between the ends. If there are as
+     * many of them as there are blocks between the ends, they start in every one, and no block is missing.
+     *
+     * @param firstKey a key in the first block, {@code firstKey <= lastKey}
+     * @param lastKey a key in the last block
+     */
+    protected boolean hasSpanForEveryBlockBetween(final long firstKey, final long lastKey) {
+        final long firstBlockKey = highBits(firstKey);
+        final long lastBlockKey = highBits(lastKey);
+        final int firstIdx = getSpanIndex(firstBlockKey);
+        if (firstIdx < 0) {
+            return false;
+        }
+        final int lastIdx = getSpanIndex(firstIdx, lastBlockKey);
+        if (lastIdx < 0) {
+            return false;
+        }
+        // One span holding both end blocks covers everything between them.
+        return lastIdx == firstIdx || lastIdx - firstIdx == distanceInBlocks(firstBlockKey, lastBlockKey);
     }
 
     public static boolean isFullBlockSpan(final Object s) {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
@@ -1778,9 +1778,13 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
      * @param sr the ranges about to be inserted
      */
     private void makeRoomForPartiallyCoveredBlocks(final long shiftAmount, final SortedRanges sr) {
-        if (size < PARTIAL_BLOCK_PREPASS_MIN_SPANS || sr.isEmpty()) {
+        if (size == 0 || sr.isEmpty()) {
+            // Nothing to make room in, or nothing to make room for; an insert into no spans takes its append path.
+            return;
+        }
+        if (size < PARTIAL_BLOCK_PREPASS_MIN_SPANS) {
             // Shifting a short spans array once per new span costs less than this pass over the ranges, even when
-            // every range starts a new span; with no spans at all the insert takes its append path.
+            // every range starts a new span.
             return;
         }
         if (hasSpanForEveryBlockBetween(sr.first() + shiftAmount, sr.last() + shiftAmount)) {

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
@@ -7,6 +7,7 @@ import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.chunk.LongChunk;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.rowset.impl.OrderedLongSet;
 import io.deephaven.engine.rowset.impl.OrderedLongSetBuilderSequential;
 import io.deephaven.engine.rowset.impl.RowSetUtils;
@@ -1752,7 +1753,8 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
      * nanoseconds per range; below this many spans, shifting the tail of the arrays once per new span costs less than
      * that, even when every range starts a new span.
      */
-    private static final int PARTIAL_BLOCK_PREPASS_MIN_SPANS = 256;
+    static final int PARTIAL_BLOCK_PREPASS_MIN_SPANS = Configuration.getInstance().getIntegerForClassWithDefault(
+            RspBitmap.class, "partialBlockPrePassMinSpans", 256);
 
     public void insertOrderedLongSetUnsafeNoWriteCheck(final SortedRanges sr) {
         makeRoomForPartiallyCoveredBlocks(0, sr);

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspBitmap.java
@@ -1747,6 +1747,13 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
         addRangeUnsafeNoWriteCheck(0, ix.ixFirstKey(), ix.ixLastKey());
     }
 
+    /**
+     * Fewest spans for which {@link #makeRoomForPartiallyCoveredBlocks} can pay for itself. The pass costs a few
+     * nanoseconds per range; below this many spans, shifting the tail of the arrays once per new span costs less than
+     * that, even when every range starts a new span.
+     */
+    private static final int PARTIAL_BLOCK_PREPASS_MIN_SPANS = 256;
+
     public void insertOrderedLongSetUnsafeNoWriteCheck(final SortedRanges sr) {
         makeRoomForPartiallyCoveredBlocks(0, sr);
         addRangesUnsafeNoWriteCheck(sr.getRangeIterator());
@@ -1769,8 +1776,14 @@ public class RspBitmap extends RspArray<RspBitmap> implements OrderedLongSet {
      * @param sr the ranges about to be inserted
      */
     private void makeRoomForPartiallyCoveredBlocks(final long shiftAmount, final SortedRanges sr) {
-        if (size == 0) {
-            // Nothing to make room in; the insert takes its append path.
+        if (size < PARTIAL_BLOCK_PREPASS_MIN_SPANS || sr.isEmpty()) {
+            // Shifting a short spans array once per new span costs less than this pass over the ranges, even when
+            // every range starts a new span; with no spans at all the insert takes its append path.
+            return;
+        }
+        if (hasSpanForEveryBlockBetween(sr.first() + shiftAmount, sr.last() + shiftAmount)) {
+            // Every block the ranges touch has a span already, so there is no room to make. Two searches settle that,
+            // where the pass below would search once per range to find the same thing.
             return;
         }
         final WorkData wd = workDataPerThread.get();

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapInsertPrePassGateTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapInsertPrePassGateTest.java
@@ -1,0 +1,180 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.rowset.impl.rsp;
+
+import io.deephaven.engine.rowset.impl.OrderedLongSet;
+import io.deephaven.engine.rowset.impl.RowSetTestCommon;
+import io.deephaven.engine.rowset.impl.sortedranges.SortedRanges;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.deephaven.engine.rowset.impl.RowSetTestCommon.render;
+import static io.deephaven.engine.rowset.impl.RowSetTestCommon.shiftRanges;
+import static io.deephaven.engine.rowset.impl.RowSetTestCommon.sortedRangesImplOf;
+import static io.deephaven.engine.rowset.impl.RowSetTestCommon.unionRanges;
+import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Inserting a {@link SortedRanges} into an {@link RspBitmap} makes room for new spans ahead of time only when that can
+ * pay off: above {@link RspBitmap#PARTIAL_BLOCK_PREPASS_MIN_SPANS} spans, and only if some block the ranges touch has
+ * no span yet. These cover the two ways it is skipped, the test that decides the second, and the search fast path the
+ * insert leans on when consecutive ranges share a block.
+ */
+public class RspBitmapInsertPrePassGateTest {
+
+    private static final long BS = BLOCK_SIZE;
+    private static final int OVER_GATE = RspBitmap.PARTIAL_BLOCK_PREPASS_MIN_SPANS + 50;
+
+    /** A singleton span in every block from {@code firstBlock} for {@code blocks} blocks. */
+    private static RspBitmap singletonsAtEveryBlock(final long firstBlock, final int blocks) {
+        RspBitmap rb = RspBitmap.makeEmpty();
+        for (int i = 0; i < blocks; ++i) {
+            rb = rb.appendUnsafe((firstBlock + i) * BS + 7);
+        }
+        rb.finishMutations();
+        return rb;
+    }
+
+    private static List<long[]> rangesOf(final SortedRanges sr) {
+        final List<long[]> out = new ArrayList<>();
+        sr.forEachLongRange((s, e) -> {
+            out.add(new long[] {s, e});
+            return true;
+        });
+        return out;
+    }
+
+    private static void checkInsert(final RspBitmap receiver, final SortedRanges sr, final String what) {
+        final String expected = render(unionRanges(RowSetTestCommon.rangesOf(receiver), rangesOf(sr)));
+        final RspBitmap w = receiver.deepCopy();
+        w.insertOrderedLongSetUnsafeNoWriteCheck(sr);
+        w.finishMutations();
+        w.validate(what);
+        assertEquals(what, expected, render(RowSetTestCommon.rangesOf(w)));
+    }
+
+    @Test
+    public void testEveryBlockPresentWhenSpansAreContiguous() {
+        final RspBitmap rb = singletonsAtEveryBlock(0, 10);
+        assertTrue(rb.hasSpanForEveryBlockBetween(2 * BS + 1, 7 * BS + 1));
+        assertTrue(rb.hasSpanForEveryBlockBetween(0, 10 * BS - 1));
+        assertTrue(rb.hasSpanForEveryBlockBetween(3 * BS, 3 * BS + 100));
+    }
+
+    @Test
+    public void testMissingBlockIsDetectedWhereverItFalls() {
+        RspBitmap rb = singletonsAtEveryBlock(0, 5); // blocks 0..4
+        for (int i = 6; i < 10; ++i) { // blocks 6..9; block 5 is missing
+            rb = rb.appendUnsafe(i * BS + 7);
+        }
+        rb.finishMutations();
+        assertFalse("gap inside", rb.hasSpanForEveryBlockBetween(2 * BS, 8 * BS));
+        assertFalse("first block missing", rb.hasSpanForEveryBlockBetween(5 * BS, 8 * BS));
+        assertFalse("last block missing", rb.hasSpanForEveryBlockBetween(2 * BS, 5 * BS));
+        assertFalse("only block missing", rb.hasSpanForEveryBlockBetween(5 * BS + 1, 5 * BS + 2));
+        assertFalse("past our end", rb.hasSpanForEveryBlockBetween(8 * BS, 12 * BS));
+        assertFalse("before our start", rb.hasSpanForEveryBlockBetween(0, 12 * BS));
+    }
+
+    @Test
+    public void testFullBlockSpans() {
+        RspBitmap rb = RspBitmap.makeEmpty();
+        rb = rb.appendRangeUnsafe(0, 4 * BS - 1); // full block span over blocks 0..3
+        rb = rb.appendUnsafe(4 * BS + 7);
+        rb = rb.appendUnsafe(5 * BS + 7);
+        rb.finishMutations();
+        assertTrue("both ends in the full block span", rb.hasSpanForEveryBlockBetween(BS + 1, 2 * BS + 1));
+        assertTrue("whole full block span", rb.hasSpanForEveryBlockBetween(0, 4 * BS - 1));
+        assertTrue("singletons only", rb.hasSpanForEveryBlockBetween(4 * BS, 5 * BS));
+        // The span count under-counts the blocks a multi-block span covers, so this window reads as incomplete even
+        // though it is not; the insert then makes its full pass, and finds nothing to do.
+        assertFalse(rb.hasSpanForEveryBlockBetween(BS, 5 * BS));
+    }
+
+    /** Below the gate every insert skips the pass; this covers ranges in blocks we have, lack, and beyond our end. */
+    @Test
+    public void testInsertBelowGate() {
+        RspBitmap rb = RspBitmap.makeEmpty();
+        for (int i = 0; i < 20; i += 2) {
+            rb = rb.appendUnsafe(i * BS + 7);
+        }
+        rb.finishMutations();
+        checkInsert(rb, sortedRangesImplOf(new long[] {2 * BS + 1, 2 * BS + 3}, new long[] {3 * BS + 1, 3 * BS + 3},
+                new long[] {7 * BS + 1, 9 * BS + 3}, new long[] {30 * BS + 1, 30 * BS + 3}), "below gate");
+    }
+
+    /** Above the gate with every block present, the pass is skipped by the coverage test. */
+    @Test
+    public void testInsertAboveGateIntoCoveredBlocks() {
+        final RspBitmap rb = singletonsAtEveryBlock(0, OVER_GATE);
+        SortedRanges sr = SortedRanges.makeSingleRange(10 * BS + 1, 10 * BS + 3);
+        for (int i = 11; i < OVER_GATE; i += 3) {
+            sr = sr.addRange(i * BS + 1, i * BS + 3);
+            sr = sr.addRange(i * BS + 5, i * BS + 9);
+        }
+        checkInsert(rb, sr, "covered blocks above gate");
+    }
+
+    /** Above the gate with blocks missing, the pass runs and makes room for them. */
+    @Test
+    public void testInsertAboveGateIntoMissingBlocks() {
+        RspBitmap rb = RspBitmap.makeEmpty();
+        for (int i = 0; i < OVER_GATE; ++i) {
+            rb = rb.appendUnsafe(2L * i * BS + 7); // even blocks only
+        }
+        rb.finishMutations();
+        SortedRanges sr = SortedRanges.makeSingleRange(BS + 1, BS + 3);
+        for (int i = 3; i < 2 * OVER_GATE; i += 4) {
+            sr = sr.addRange(i * BS + 1, i * BS + 3); // odd blocks we lack
+            sr = sr.addRange((i + 1) * BS + 100, (i + 1) * BS + 200); // even blocks we have
+        }
+        checkInsert(rb, sr, "missing blocks above gate");
+    }
+
+    /** The shifted insert makes the same decisions, on the shifted keys. */
+    @Test
+    public void testShiftedInsertAboveGate() {
+        final RspBitmap receiver = singletonsAtEveryBlock(100, OVER_GATE);
+        SortedRanges sr = SortedRanges.makeSingleRange(1, 3);
+        for (int i = 1; i < 30; ++i) {
+            sr = sr.addRange(i * BS + 1, i * BS + 3);
+        }
+        for (final long shift : new long[] {100 * BS, 100 * BS + 100, 50 * BS, 400 * BS + 5}) {
+            final String expected =
+                    render(unionRanges(RowSetTestCommon.rangesOf(receiver), shiftRanges(rangesOf(sr), shift)));
+            final OrderedLongSet result = receiver.deepCopy().ixInsertWithShift(shift, sr);
+            final List<long[]> got = new ArrayList<>();
+            result.ixForEachLongRange((s, e) -> {
+                got.add(new long[] {s, e});
+                return true;
+            });
+            assertEquals("shift " + shift, expected, render(got));
+            ((RspBitmap) result).validate("shift " + shift);
+        }
+    }
+
+    /** A search that starts at the span holding the key returns it, and otherwise behaves as before. */
+    @Test
+    public void testSearchFromTheSpanHoldingTheKey() {
+        final RspBitmap rb = singletonsAtEveryBlock(0, 20);
+        assertEquals(5, rb.getSpanIndex(5, 5 * BS + 1));
+        assertEquals(6, rb.getSpanIndex(5, 6 * BS + 1));
+        assertEquals(19, rb.getSpanIndex(5, 19 * BS + 1));
+        assertEquals("a key before the start is reported as not found there", -6, rb.getSpanIndex(5, 4 * BS + 1));
+        assertEquals(-21, rb.getSpanIndex(5, 25 * BS));
+
+        RspBitmap withFull = RspBitmap.makeEmpty();
+        withFull = withFull.appendRangeUnsafe(0, 4 * BS - 1); // full block span over blocks 0..3
+        withFull = withFull.appendUnsafe(4 * BS + 7);
+        withFull.finishMutations();
+        assertEquals("a key inside the starting full block span, not at its first block", 0,
+                withFull.getSpanIndex(0, 2 * BS + 1));
+        assertEquals(1, withFull.getSpanIndex(0, 4 * BS + 1));
+    }
+}

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapSortedRangesInsertTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapSortedRangesInsertTest.java
@@ -68,7 +68,8 @@ public class RspBitmapSortedRangesInsertTest {
     private static void checkInsertOnce(final RspBitmap receiver, final SortedRanges sr, final String what) {
         // Compared as ranges: the fixtures hold whole blocks, far too many keys to enumerate.
         final String expected = render(unionRanges(RowSetTestCommon.rangesOf(receiver), rangesOf(sr)));
-        final RspBitmap w = receiver.writeCheck();
+        // A copy, so the receiver is still the fixture when it is inserted into again in another form.
+        final RspBitmap w = receiver.deepCopy();
         w.insertOrderedLongSetUnsafeNoWriteCheck(sr);
         w.finishMutations();
         w.validate("after insert, " + what);

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapSortedRangesInsertTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapSortedRangesInsertTest.java
@@ -40,14 +40,39 @@ public class RspBitmapSortedRangesInsertTest {
         return out;
     }
 
+    /**
+     * The block the padding spans start at; every fixture and range in these tests sits well below it, so padding
+     * changes nothing about how the ranges relate to the fixture, only how many spans the receiver has.
+     */
+    private static final long PADDING_FIRST_BLOCK = 100_000;
+
+    /**
+     * The receiver with enough singleton spans appended, far past anything the tests touch, to take it over
+     * {@link RspBitmap#PARTIAL_BLOCK_PREPASS_MIN_SPANS}. The insert only makes room ahead of time above that many
+     * spans, so this is what exercises that pass; the unpadded fixtures exercise the insert without it.
+     */
+    private static RspBitmap padded(final RspBitmap receiver) {
+        RspBitmap rb = receiver.deepCopy();
+        for (int i = 0; i <= RspBitmap.PARTIAL_BLOCK_PREPASS_MIN_SPANS; ++i) {
+            rb = rb.appendUnsafe((PADDING_FIRST_BLOCK + i) * BS + 7);
+        }
+        rb.finishMutations();
+        return rb;
+    }
+
     private static void checkInsert(final RspBitmap receiver, final SortedRanges sr) {
+        checkInsertOnce(receiver, sr, "unpadded");
+        checkInsertOnce(padded(receiver), sr, "padded");
+    }
+
+    private static void checkInsertOnce(final RspBitmap receiver, final SortedRanges sr, final String what) {
         // Compared as ranges: the fixtures hold whole blocks, far too many keys to enumerate.
         final String expected = render(unionRanges(RowSetTestCommon.rangesOf(receiver), rangesOf(sr)));
         final RspBitmap w = receiver.writeCheck();
         w.insertOrderedLongSetUnsafeNoWriteCheck(sr);
         w.finishMutations();
-        w.validate("after insert");
-        assertEquals(expected, render(RowSetTestCommon.rangesOf(w)));
+        w.validate("after insert, " + what);
+        assertEquals(what, expected, render(RowSetTestCommon.rangesOf(w)));
     }
 
     private static RspBitmap containersAtEvenBlocks(final int blocks) {
@@ -305,19 +330,21 @@ public class RspBitmapSortedRangesInsertTest {
         for (int j = 1; j < 12; ++j) {
             sr = sr.addRange(3L * j * BS, (3L * j + 2) * BS - 1);
         }
-        for (final long shift : new long[] {0, BS, 100, BS + 100}) {
-            final String expected =
-                    render(unionRanges(RowSetTestCommon.rangesOf(receiver), shiftRanges(rangesOf(sr), shift)));
-            final RspBitmap w = receiver.deepCopy();
-            final OrderedLongSet result = w.ixInsertWithShift(shift, sr);
-            final List<long[]> got = new ArrayList<>();
-            result.ixForEachLongRange((s, e) -> {
-                got.add(new long[] {s, e});
-                return true;
-            });
-            assertEquals("shift " + shift, expected, render(got));
-            if (result instanceof RspBitmap) {
-                ((RspBitmap) result).validate("shift " + shift);
+        for (final RspBitmap target : new RspBitmap[] {receiver, padded(receiver)}) {
+            for (final long shift : new long[] {0, BS, 100, BS + 100}) {
+                final String expected =
+                        render(unionRanges(RowSetTestCommon.rangesOf(target), shiftRanges(rangesOf(sr), shift)));
+                final RspBitmap w = target.deepCopy();
+                final OrderedLongSet result = w.ixInsertWithShift(shift, sr);
+                final List<long[]> got = new ArrayList<>();
+                result.ixForEachLongRange((s, e) -> {
+                    got.add(new long[] {s, e});
+                    return true;
+                });
+                assertEquals("shift " + shift, expected, render(got));
+                if (result instanceof RspBitmap) {
+                    ((RspBitmap) result).validate("shift " + shift);
+                }
             }
         }
     }


### PR DESCRIPTION
DH-23407 (#8413) added `RspBitmap.makeRoomForPartiallyCoveredBlocks`, a pre-pass over an incoming `SortedRanges` that creates every span the insert will need in one shot, so inserting `m` ranges that start new blocks into an `n`-span bitmap is not O(n·m). The pre-pass ran unconditionally, and it costs a flat 5–10 ns per incoming range whether or not any range starts a new block.

The nightly benchmarks caught the cost: bucketed incremental `updateBy` (`Rolling*Tick- 3 Groups 100K Unique Combos -Inc`) dropped 24–32% between the 2026-08-26 and 2026-08-27 images, scaling with bucket count and absent from the static and no-group runs. `updateBy` accumulates each dirty bucket's small, sparse affected-row set into one row set per cycle, so the accumulator takes one `SortedRanges` insert per bucket, and after the first few buckets every block it touches already has a span. On a 10M-row table that accumulator never exceeds 10 spans (10K buckets) or 79 (100K buckets), so there is nothing for the pre-pass to save.

## Change

- `makeRoomForPartiallyCoveredBlocks` returns early below 256 spans. Shifting the array costs about 0.07 ns per entry per new span and the pre-pass about 5–10 ns per range, so it can only pay off when `spans > ~150 · ranges / newSpans`, and new spans can never outnumber ranges.
- Above that, it returns early when `RspArray.hasSpanForEveryBlockBetween` proves, with two searches, that every block between the incoming set's first and last key already has a span. The proof is in its javadoc; it is sufficient, not necessary, so an insert that would create a span always still gets the pre-pass.
- `RspArray.keySearch` checks the caller's start slot before bisecting. Callers walking ascending keys usually land in the span they last found. Worth 8–20% on inserts whose consecutive ranges share a block in arrays of 9+ spans, neutral otherwise.

## Measurements

Two JMH benchmarks are added under `engine/benchmark`. `RowSetIncrementalInsertBench` models one `updateBy` cycle; `RspSortedRangesInsertShapeBench` sweeps spans × ranges × new-span fraction.

Modeled cycle, ms per cycle, pre-pass path vs the pre-DH-23407 body of the same method:

| buckets | direct | pre-pass, before | pre-pass, after |
|---|---|---|---|
| 10,000 | 8.6 | 11.2 | 8.5 |
| 100,000 | 106 | 137 | 106 |

A 307-span accumulator (100M rows, 200-row window), which is above the gate, lands at 429 vs 434 ms, so the nothing-new test fires on the real shape.

The large-versus-large case the pre-pass exists for is unchanged. Net insert time, pre-pass path:

| spans | ranges | new spans | before | after | direct, for scale |
|---|---|---|---|---|---|
| 8192 | 1024 | 1024 | 33.1 µs | 34.2 µs | 574 µs |
| 8192 | 4096 | 4096 | 117.0 µs | 116.2 µs | 2,296 µs |
| 32768 | 1024 | 1024 | 38.7 µs | 39.9 µs | 2,952 µs |
| 32768 | 4096 | 4096 | 137.9 µs | 136.4 µs | 11,634 µs |

Full shape matrix after the change: below 256 spans both paths are within 5% of each other; above it, rows with new spans are unchanged. The remaining known cost is a target with gaps inside the incoming key window and no new spans, where the pre-pass still runs at 1.4–1.6× of a small insert; closing that would take a sampling estimate or a fused single pass.

`:engine-rowset:test` passes (603 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT1uBG9N4RWsWXd9SxXeg8
