### PR TITLE
chore: DH-23636: Add gomod ecosystem to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,16 @@ updates:
     assignees:
       - "devinrsmith"
       - "rcaudy"
+  - package-ecosystem: "gomod"
+    directory: "/go"
+    open-pull-requests-limit: 99
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(gomod)"
+    labels:
+      - "NoDocumentationNeeded"
+      - "NoReleaseNotesNeeded"
+      - "version-bump"
+    assignees:
+      - "cpwright"


### PR DESCRIPTION
The Go client module at go/go.mod had no Dependabot coverage, so it never
received automated dependency-update PRs. Three google.golang.org/grpc
security advisories accumulated against it and had to be fixed by hand in
#8509.

The new entry mirrors the existing github-actions and gradle entries:
weekly schedule, the same labels, and a chore(gomod) commit prefix.
