### PR TITLE
fix: DH-23647: Pull the minio image from quay.io instead of Docker Hub

### DIFF
--- a/docker/registry/minio/gradle.properties
+++ b/docker/registry/minio/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
-deephaven.registry.imageName=minio/minio:latest
-deephaven.registry.imageId=minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+deephaven.registry.imageName=quay.io/minio/minio:latest
+deephaven.registry.imageId=quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e


### PR DESCRIPTION
Fixes the nightly `testOutOfBand` failure by pulling the MinIO image from quay.io instead of Docker Hub.

## Why

`minio/minio` has been **deleted from Docker Hub**. Nothing in our repo changed — our pin has not been touched since #7224 (2025-09-25) — the upstream image disappeared out from under us.

Nightly run [34677527101](https://github.com/deephaven/deephaven-core/actions/runs/34677527101) failed on both `testOutOfBand` jobs (Java 21 and Java 25) with the same error, in image acquisition rather than in any test:

```
> Task :docker-minio:tagLocalBuild FAILED
Step 1/1 : FROM minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
> Could not build image: pull access denied for minio/minio,
  repository does not exist or may require 'docker login':
  denied: requested access to the resource is denied
```

That blocks every suite depending on the MinIO container: `extensions/s3`, `extensions/iceberg/s3`, and `extensions/parquet/table`.

Verified against the live registry and Hub APIs:

| Repository | registry-1.docker.io `latest` | hub.docker.com API |
| --- | --- | --- |
| `library/alpine` | 200 | 200 |
| `localstack/localstack` | 200 | 200 |
| `minio/minio` | **401** | **404** |
| `minio/mc` | **401** | **404** |

The `minio` namespace still exists and lists 20 repositories (`mint`, `warp`, `operator`, …), but `minio/minio` and `minio/mc` are no longer among them. This is the tail end of MinIO's container-distribution shutdown — they stopped publishing images in October 2025, marked the repo unmaintained in February 2026, and archived it on 2026-04-25.

## The change

quay.io still serves **the exact digest we already pin**, so this is a content-identical swap — same manifest list (linux/amd64, arm64, ppc64le), same bits:

```
quay.io/minio/minio:latest → sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
```

Only the registry host changes. The resulting `gradle.properties` is exactly what `:docker-minio:bumpImage` would write for this image, and `docker/registry/manylinux2014_x86_64` is existing precedent for a quay.io-hosted registry project.

## Testing

Pushed as a `nightly/**` branch so Nightly Check CI runs on it — that is the real verification, since the failure only reproduces where the image actually gets pulled. (A Docker daemon isn't available in my local sandbox.)

## Follow-up

This unblocks the nightly but is not durable, and is worth tracking separately:

- quay.io's copy is frozen at the October 2025 cutoff — no new releases are coming, and `latest` there is already stale.
- MinIO could remove the quay.io repository the same way they removed Docker Hub, and we would break again with no warning.

Longer term we should get off the upstream MinIO image: build it ourselves from source, move the S3 tests to LocalStack (we already have `docker/registry/localstack`), or adopt a maintained rebuild.
