### PR TITLE
test: no-ticket: Increase TableSpecTestBase timeout to 20 seconds

### DIFF
--- a/java-client/session-dagger/src/test/java/io/deephaven/client/TableSpecTestBase.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/TableSpecTestBase.java
@@ -31,21 +31,21 @@ public abstract class TableSpecTestBase extends DeephavenSessionTestBase {
         this.table = Objects.requireNonNull(table);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void batch() throws TableHandleException, InterruptedException {
         try (final TableHandle handle = session.batch().execute(table)) {
             assertThat(handle.isSuccessful()).isTrue();
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void serial() throws TableHandleException, InterruptedException {
         try (final TableHandle handle = session.serial().execute(table)) {
             assertThat(handle.isSuccessful()).isTrue();
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     public void async() throws ExecutionException, InterruptedException {
         try (final TableHandle handle = session.executeAsync(table).getOrCancel()) {
             assertThat(handle.isSuccessful()).isTrue();


### PR DESCRIPTION
`TableSpecTestBase.batch()`, `serial()` and `async()` carry `@Test(timeout = 10000)`. That budget covers only the test body — JUnit's `methodBlock` applies `withPotentialTimeout` before `withBefores`, so the per-test in-process server startup runs outside it and the full 10s has to be absorbed by the single `execute(table)` call.

The first test in each of these parameterized classes pays a large one-time cost, because the table spec's base is a `view()` with eight formula columns that the server compiles cold:

```java
TableSpec.empty(1000).view("Key=ii%3", "Key2=ii%17", "B=(byte)ii", "S=(short)ii",
                           "I=(int)ii", "L=(long)ii", "F=(float)ii", "D=(double)ii");
```

Timings from a recent nightly `check` on Java 21:

| | slowest | 2nd | 3rd | median |
|---|---|---|---|---|
| `AggAllBySessionTest` (738 tests) | **13.947s FAIL** | 3.883s | 2.241s | 0.168s |
| `AggBySessionTest` (540 tests) | **14.412s FAIL** | 2.941s | 2.126s | 0.200s |

Both failures are the first test executed in their class, and in each case the 2nd- and 3rd-slowest tests are the same spec's siblings — a decaying warm-up curve with roughly a 70x gap between the first test and the median. The two failed 17ms apart in separate forked JVMs, so the trigger was a machine-wide stall rather than anything specific to those specs.

The runner is heavily oversubscribed by design: `test.maxParallelForks = Runtime.runtime.availableProcessors()` with `maxHeapSize = 3g` per fork, alongside `org.gradle.parallel=true` and `org.gradle.workers.max=3`. 10s of headroom for a cold javac run under that load is simply too tight.

20s matches `TableServiceAsyncTest` in the same module, which already uses `@Test(timeout = 20000)` for comparable work.
